### PR TITLE
configurable notification mailer

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -68,7 +68,7 @@ class Notification < ActiveRecord::Base
         if Mailboxer.uses_emails
           email_to = r.send(Mailboxer.email_method,self)
           unless email_to.blank?
-            NotificationMailer.send_email(self,r).deliver
+            get_mailer.send_email(self,r).deliver
           end
         end
       end
@@ -76,6 +76,9 @@ class Notification < ActiveRecord::Base
     end
     return temp_receipts if temp_receipts.size > 1
     return temp_receipts.first
+  end
+  def get_mailer
+    Mailboxer.notification_mailer || NotificationMailer
   end
 
   #Returns the recipients of the Notification

--- a/lib/mailboxer.rb
+++ b/lib/mailboxer.rb
@@ -15,7 +15,8 @@ module Mailboxer
   @@email_method = :mailboxer_email
   mattr_accessor :name_method
   @@name_method = :name
-  
+  mattr_accessor :notification_mailer
+
    class << self
     def setup
       yield self

--- a/spec/mailboxer_spec.rb
+++ b/spec/mailboxer_spec.rb
@@ -4,4 +4,15 @@ describe Mailboxer do
   it "should be valid" do
     Mailboxer.should be_a(Module)
   end
+
+  describe "configuring notification mailer" do
+    before { Mailboxer.notification_mailer.should eq nil }
+
+    it "can override notification mailer" do
+      Mailboxer.notification_mailer = "foo"
+      Mailboxer.notification_mailer.should eq "foo"
+    end
+
+    after { Mailboxer.notification_mailer.should eq nil }
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -60,5 +60,18 @@ describe Message do
     notification.body.should=="Body"
           
   end
-    
+
+  describe "#get_mailer obtains mailer from config" do
+    before { Mailboxer.notification_mailer.should be_nil }
+
+    it "defaults to NotificationMailer" do
+      subject.get_mailer.should eq NotificationMailer
+    end
+    it "can be overriden on Mailboxer" do
+      Mailboxer.notification_mailer = 'foo'
+      subject.get_mailer.should eq 'foo'
+    end
+
+    after { Mailboxer.notification_mailer = nil }
+  end
 end


### PR DESCRIPTION
Hi  there, 

I have introduced a config option on Mailboxer and adjusted the notification model so that we can change the mailer that will be used when sending emails. My motivation behind this change is, that I would like to offload sending mails to a background processing tool like resque. 

If you are happy with the change, I would also make a similar change for the MessageMailer. 

cheers
