### PR TITLE
Fix bad conditional on hash with false value

### DIFF
--- a/app/models/mailbox.rb
+++ b/app/models/mailbox.rb
@@ -42,7 +42,7 @@ class Mailbox
       end
     end
 
-    if (options[:read].present? and options[:read]==false) or (options[:unread].present? and options[:unread]==true)
+    if (options.has_key?(:read) && options[:read]==false) || (options.has_key?(:unread) && options[:unread]==true)
       conv = conv.unread(@messageable)
     end
 

--- a/spec/models/mailbox_spec.rb
+++ b/spec/models/mailbox_spec.rb
@@ -67,6 +67,12 @@ describe Mailbox do
     @entity2.mailbox.receipts.inbox[0].should==Receipt.recipient(@entity2).inbox.conversation(@conversation)[0]
     @entity2.mailbox.receipts.inbox[1].should==Receipt.recipient(@entity2).inbox.conversation(@conversation)[1]
   end
+
+  it "should understand the read option" do
+    @entity1.mailbox.inbox(read: false).count.should_not == 0
+    @conversation.mark_as_read(@entity1)
+    @entity1.mailbox.inbox(read: false).count.should == 0
+  end
   
   it "should return trashed mails" do 
     @entity1.mailbox.receipts.move_to_trash


### PR DESCRIPTION
- It turns out that `{:foo => false}[:foo].present?` is `false` which caused the condition check to fail and passing `{:read => false}` to still return read messages.
- "and" and "or" are almost never what you really want: [http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/](http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/)
