### PR TITLE
Bugfix for handling general enumerables instead of Arrays

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,8 +26,8 @@ class Notification < ActiveRecord::Base
     #Sends a Notification to all the recipients
     def notify_all(recipients,subject,body,obj = nil,sanitize_text = true,notification_code=nil)
       notification = Notification.new({:body => body, :subject => subject})
-      notification.recipients = recipients.is_a?(Array) ? recipients : [recipients]
-      notification.recipients = notification.recipients.uniq
+      notification.recipients = recipients.respond_to?(:each) ? recipients : [recipients]
+      notification.recipients = notification.recipients.uniq if recipients.respond_to?(:uniq)
       notification.notified_object = obj if obj.present?
       notification.notification_code = notification_code if notification_code.present?
       return notification.deliver sanitize_text

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -41,7 +41,8 @@ describe Message do
   end
   
   it "should notify several users" do
-    Notification.notify_all([@entity1,@entity2,@entity3],"Subject","Body")
+    recipients = Set.new [@entity1,@entity2,@entity3]
+    Notification.notify_all(recipients,"Subject","Body")
     
     #Check getting ALL receipts
     @entity1.mailbox.receipts.size.should==1
@@ -74,6 +75,23 @@ describe Message do
     notification.subject.should=="Subject"
     notification.body.should=="Body"
           
+  end
+
+  it "should notify a single recipient" do
+    Notification.notify_all(@entity1,"Subject","Body")
+
+    #Check getting ALL receipts
+    @entity1.mailbox.receipts.size.should==1
+    receipt = @entity1.mailbox.receipts.first
+    notification = receipt.notification
+    notification.subject.should=="Subject"
+    notification.body.should=="Body"
+
+    #Check getting NOTIFICATION receipts only
+    @entity1.mailbox.notifications.size.should==1
+    notification = @entity1.mailbox.notifications.first
+    notification.subject.should=="Subject"
+    notification.body.should=="Body"
   end
 
 end


### PR DESCRIPTION
In the case that the `recipients` parameter to `Notification#notify_all` is a non-`Array` enumerable this method would wrap it up in an Array, which would lead to an error.  A good example of this is the case where recipients is an `ActiveRecord::Relation` from `User#where` for instance.  By checking instead that the `recipients` parameter responds to  `:each` (and `uniq` where appropriate) this latter, standard Rails case, is covered.
