### PR TITLE
Updated readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,27 @@ Installation
 
 Add to your Gemfile:
 
-````
-gem ‘mailboxer’
-````
+```ruby
+gem 'mailboxer'
+```
 
 Then run:
 
-````
+```sh
 $ bundle update
-````
+```
 
 Run install script:
 
-````
+```sh
 $ rails g mailboxer:install
-````
+```
 
 And don't forget to migrate you database:
 
-````
+```sh
 $ rake db:migrate
-````
+```
 
 ## Requirements & Settings
 
@@ -62,7 +62,7 @@ $ rake db:migrate
 
 We are now adding support for sending emails when a Notification or a Message is sent to one o more recipients. You should modify mailboxer initializer (/config/initializer/mailboxer.rb) to edit this settings.
 
-````ruby
+```ruby
 Mailboxer.setup do |config|
   #Configures if you applications uses or no the email sending for Notifications and Messages
   config.uses_emails = true  
@@ -70,30 +70,30 @@ Mailboxer.setup do |config|
   config.default_from = "no-reply@dit.upm.es"
   ...
 end
-````
+```
 
 You can change the way in which emails are delivered by specifying a custom implementation for notification and message mailer 
 
-````ruby
+```ruby
 Mailboxer.setup do |config|
   config.notification_mailer = CustomNotificationMailer
   config.message_mailer = CustomMessageMailer
   ...
 end
-````
+```
 
 ### User identities
 
 Users must have an identity defined by a `name` and an `email`. We must assure that Messageable models have some specific methods. These methods are:
 
-````ruby
+```ruby
 #Returning any kind of identification you want for the model
 def name
   return "You should add method :name in your Messageable model"
 end
-````
+```
 
-````ruby
+```ruby
 #Returning the email address of the model if an email should be sent for this object (Message or Notification).
 #If no mail has to be sent, return nil.
 def mailboxer_email(object)
@@ -103,11 +103,11 @@ def mailboxer_email(object)
   #if false
   #return nil
 end
-````
+```
 
 These names are explicit enough to avoid colliding with other methods, but as long as you need to change them you can do it by using mailboxer initializer (/config/initializer/mailboxer.rb). Just add or uncomment the following lines:
 
-````ruby
+```ruby
 Mailboxer.setup do |config|
   # ...
   #Configures the methods needed by mailboxer
@@ -115,14 +115,14 @@ Mailboxer.setup do |config|
   config.name_method = :name
   # ...
 end
-````
+```
 
 You may change whatever you want or need. For example:
 
-````ruby
+```ruby
 config.email_method = :notifications_email
 config.name_method = :display_name
-````
+```
 
 Will use the method `notification_email(object)` instead of `mailboxer_email(object)` and `display_name` for `name`.
 
@@ -132,80 +132,87 @@ Using default or custom method names, if your model doesn't implement them, Mail
 
 In your model:
 
-````ruby
+```ruby
 class User < ActiveRecord::Base
   acts_as_messageable
 end
-````
+```
 
 You are not limited to User model. You can use Mailboxer in any other model and use it in serveral different models. If you have ducks and cylons in your application and you want to interchange messages as if they where the same, just use act_as_messageable in each one and you will be able to send duck-duck, duck-cylon, cylon-duck and cylon-cylon messages. Of course, you can extend it for as many clases as you need.
 
 Example:
 
-````ruby
+```ruby
 class Duck < ActiveRecord::Base
   acts_as_messageable
 end
-````
+```
 
-````ruby
+```ruby
 class Cylon < ActiveRecord::Base
   acts_as_messageable
 end
-````
+```
 
 ## Mailboxer API
 
 ### How can I send a message?
 
-````ruby
-  #alfa wants to send a message to beta
-  alfa.send_message(beta, "Body", "subject")
-````
+```ruby
+#alfa wants to send a message to beta
+alfa.send_message(beta, "Body", "subject")
+```
 
 ### How can I reply a message?
 
-````ruby
-  #alfa wants to reply to all in a conversation
-  #using a receipt
-  alfa.reply_to_all(receipt, "Reply body")
-  #using a conversation
-  alfa.reply_to_conversation(conversation, "Reply body")
-````
+```ruby
+#alfa wants to reply to all in a conversation
+#using a receipt
+alfa.reply_to_all(receipt, "Reply body")
 
-````ruby
-  #alfa wants to reply to the sender of a message (and ONLY the sender)
-  #using a receipt
-  alfa.reply_to_sender(receipt, "Reply body")
-````
+#using a conversation
+alfa.reply_to_conversation(conversation, "Reply body")
+```
+
+```ruby
+#alfa wants to reply to the sender of a message (and ONLY the sender)
+#using a receipt
+alfa.reply_to_sender(receipt, "Reply body")
+```
 
 ### How can I retrieve my conversations?
 
-````ruby
-  #alfa wants to retrieve all his conversations
-  alfa.mailbox.conversations
-  #A wants to retrieve his inbox
-  alfa.mailbox.inbox
-  #A wants to retrieve his sent conversations
-  alfa.mailbox.sentbox
-  #alfa wants to retrieve his trashed conversations
-  alfa.mailbox.trash
-````
+```ruby
+#alfa wants to retrieve all his conversations
+alfa.mailbox.conversations
+
+#A wants to retrieve his inbox
+alfa.mailbox.inbox
+
+#A wants to retrieve his sent conversations
+alfa.mailbox.sentbox
+
+#alfa wants to retrieve his trashed conversations
+alfa.mailbox.trash
+```
 
 ### How can I paginate conversations?
 
 You can use Kaminari to paginate the conversations as normal. Please, make sure you use the last version as mailboxer uses `select('DISTINCT conversations.*')` which was not respected before Kaminari 0.12.4 according to its changelog. Working corretly on Kaminari 0.13.0.
 
-````ruby
-  #Paginating all conversations using :page parameter and 9 per page
-  conversations = alfa.mailbox.conversations.page(params[:page]).per(9)
-  #Paginating received conversations using :page parameter and 9 per page
-  conversations = alfa.mailbox.inbox.page(params[:page]).per(9)
-  #Paginating sent conversations using :page parameter and 9 per page
-  conversations = alfa.mailbox.sentbox.page(params[:page]).per(9)
-  #Paginating trashed conversations using :page parameter and 9 per page
-  conversations = alfa.mailbox.trash.page(params[:page]).per(9) 
-````
+```ruby
+#Paginating all conversations using :page parameter and 9 per page
+conversations = alfa.mailbox.conversations.page(params[:page]).per(9)
+
+#Paginating received conversations using :page parameter and 9 per page
+conversations = alfa.mailbox.inbox.page(params[:page]).per(9)
+  
+#Paginating sent conversations using :page parameter and 9 per page
+conversations = alfa.mailbox.sentbox.page(params[:page]).per(9)
+
+#Paginating trashed conversations using :page parameter and 9 per page
+conversations = alfa.mailbox.trash.page(params[:page]).per(9) 
+```
 
 ### How can I read the messages of a conversation?
 
@@ -213,19 +220,21 @@ As a messageable, what you receive receipts wich are linked with the message its
 
 This is done this way because receipts save the information about the relation between messageable and the messages: is it read?, is it trashed?, etc.
 
-````ruby
-  #alfa gets the last conversation (chronologically, the first in the inbox)
-  conversation = alfa.mailbox.inbox.first
-  #alfa gets it receipts chronologically ordered.
-  receipts = conversation.receipts_for alfa
-  #using the receipts (i.e. in the view)
-  receipts.each do |receipt|
-    ...
-    message = receipt.message
-    read = receipt.is_unread? #or message.is_unread?(alfa)
-    ...
-  end
-````
+```ruby
+#alfa gets the last conversation (chronologically, the first in the inbox)
+conversation = alfa.mailbox.inbox.first
+
+#alfa gets it receipts chronologically ordered.
+receipts = conversation.receipts_for alfa
+
+#using the receipts (i.e. in the view)
+receipts.each do |receipt|
+  ...
+  message = receipt.message
+  read = receipt.is_unread? #or message.is_unread?(alfa)
+  ...
+end
+```
 
 You can take a look at the full documentation of Mailboxer in [rubydoc.info](http://rubydoc.info/gems/mailboxer/frames).
 


### PR DESCRIPTION
- Markdown blocks use [GitHub Flavored Markdown](http://github.github.com/github-flavored-markdown/)
- Fixed indentation of ruby code blocks that didn't require it
