### PR TITLE
Merged changes from issue-52 to fix problems seen with send message

### DIFF
--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -114,28 +114,6 @@ module Mailboxer
         end
       end
 
-      #Mark the object as read for messageable.
-      #
-      #Object can be:
-      #* A Receipt
-      #* A Message
-      #* A Notification
-      #* A Conversation
-      #* An array with any of them
-      def nothing
-        case obj
-        when Receipt
-          return obj.mark_as_read if obj.receiver == self
-        when Message, Notification
-          obj.mark_as_read(self)
-        when Conversation
-          obj.mark_as_read(self)
-        when Array
-          obj.map{ |sub_obj| read(sub_obj) }
-        else
-          return nil
-        end
-      end
         #Mark the object as unread for messageable.
         #
         #Object can be:


### PR DESCRIPTION
These changes fix problems I was seeing with using factory_girl thanks to @atd and his changes in issue-52 . I merged his changes from issue-52 and the specs passed again.  I was however seeing the same problem with my app which doesn't use hydra-head and this is what I see:

in ./app/models/message.rb:
at line 52  

 email_to = r.send(Mailboxer.email_method,self)

it is throwing an exception from rails attribute_accesors .
However rails doesn't show the exact nature of the error. I had to use debugger to get that far. 
I changed 

 config.uses_emails = false
# and now everything runs fine.  However this problem needs more robust error handling to help with sanity in the future.
