### PR TITLE
adding timestamps to message api

### DIFF
--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -52,9 +52,13 @@ module Mailboxer
 
       #Sends a messages, starting a new conversation, with the messageable
       #as originator
-      def send_message(recipients, msg_body, subject, sanitize_text=true, attachment=nil)
+      def send_message(recipients, msg_body, subject, sanitize_text=true, attachment=nil, message_timestamp = Time.now)
         convo = Conversation.new({:subject => subject})
+        convo.created_at = message_timestamp
+        convo.updated_at = message_timestamp
         message = messages.new({:body => msg_body, :subject => subject, :attachment => attachment})
+        message.created_at = message_timestamp
+        message.updated_at = message_timestamp
         message.conversation = convo
         message.recipients = recipients.is_a?(Array) ? recipients : [recipients]
         message.recipients = message.recipients.uniq


### PR DESCRIPTION
added ability to specify timestamp to message API (https://github.com/ging/mailboxer/issues/14)

(very crude and simple implementation)
