### PR TITLE
notification.expired? shouldn't puke when expires is nil

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -54,7 +54,7 @@ class Notification < ActiveRecord::Base
   end
 
   def expired?
-    return self.expires < Time.now
+    return self.expires.present? && (self.expires < Time.now)
   end
 
   def expire!

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -188,6 +188,13 @@ describe Message do
       end
     end
     
+    context "when the expiration date is not set" do
+      before {subject.stub(:expires => nil)}
+      it 'should not be expired' do
+        subject.expired?.should be_false
+      end
+    end
+    
   end
 
 end


### PR DESCRIPTION
Apologies for the issue.  Fixed the bug, and added a spec for the same.
