### PR TITLE
Ability to add participant to existing conversation

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -106,6 +106,21 @@ class Conversation < ActiveRecord::Base
     self.receipts_for(participant).count != 0
   end
 
+	#Adds a new participant to the conversation
+	def add_participant(participant)
+		messages = self.messages
+		messages.each do |message|
+		  receipt = Receipt.new
+		  receipt.notification = message
+		  receipt.is_read = false
+		  receipt.receiver = participant
+		  receipt.mailbox_type = 'inbox'
+		  receipt.updated_at = message.updated_at
+		  receipt.created_at = message.created_at
+		  receipt.save
+		end
+	end
+
   #Returns true if the participant has at least one trashed message of the conversation
   def is_trashed?(participant)
     return false if participant.nil?

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -49,6 +49,22 @@ describe Conversation do
     @conversation.should be_is_unread(@entity1)
   end
 
+  it "should be able to add a new participant" do
+    new_user = FactoryGirl.create(:user)
+    @conversation.add_participant(new_user)
+    @conversation.participants.count.should == 3
+    @conversation.participants.should include(new_user, @entity1, @entity2)
+    @conversation.receipts_for(new_user).count.should == @conversation.receipts_for(@entity1).count
+  end
+
+  it "should deliver messages to new participants" do
+    new_user = FactoryGirl.create(:user)
+    @conversation.add_participant(new_user)
+    expect{
+      receipt5 = @entity1.reply_to_all(@receipt4,"Reply body 4")
+    }.to change{ @conversation.receipts_for(new_user).count }.by 1
+  end
+
   describe "scopes" do
     let(:participant) { FactoryGirl.create(:user) }
     let!(:inbox_conversation) { @entity1.send_message(participant, "Body", "Subject").notification.conversation }


### PR DESCRIPTION
Is there already a way to add a new participant to an existing conversation? I solved this by manually creating a receipt for the new member, because I didn't find an existing API-call. Can someone confirm or deny whether this feature exists?
EDIT: I have changed this issue to be a pull request with my code and a simple test attached.
