### PR TITLE
retrieve all not_trashed conversations

### DIFF
--- a/app/models/mailbox.rb
+++ b/app/models/mailbox.rb
@@ -39,6 +39,8 @@ class Mailbox
         conv = Conversation.sentbox(@messageable)
       when 'trash'
         conv = Conversation.trash(@messageable)
+      when  'not_trash'
+        conv = Conversation.not_trash(@messageable)
       end
     end
 


### PR DESCRIPTION
I think it would be nice to provide an entry point for retrieving all not_trashed conversations, I was in need for it. I now that i can use `Conversation.not_trash(@messable)` directly but this looks more handy.

Thanks.
