### PR TITLE
Updated conversation is_deleted? method so that it calculates the correct value

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -136,7 +136,7 @@ class Conversation < ActiveRecord::Base
   #Returns true if the participant has deleted the conversation
   def is_deleted?(participant)
     return false if participant.nil?
-    return self.receipts_for(participant).trash.count==0
+    return self.receipts_for(participant).deleted.count == self.receipts_for(participant).count
   end
 
   #Returns true if the participant has trashed all the messages of the conversation

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -120,4 +120,15 @@ describe Conversation do
       @conversation.is_completely_trashed?(@entity1).should be_true
     end
   end
+
+  describe "is_deleted?" do
+    it "returns false if a recipient has not deleted the conversation" do
+      @conversation.is_deleted?(@entity1).should be_false
+    end
+
+    it "returns true if a recipient has deleted the conversation" do
+      @conversation.mark_as_deleted(@entity1)
+      @conversation.is_deleted?(@entity1).should be_true
+    end
+  end
 end


### PR DESCRIPTION
It was previously just checking whether the receipts for that participant were not in the trash, which gives a faulty response when nothing is deleted. Now it checks whether all the receipts are deleted by that participant.
