### PR TITLE
rename module to avoid collision when subclasses inherits from AR::Base

### DIFF
--- a/lib/mailboxer/engine.rb
+++ b/lib/mailboxer/engine.rb
@@ -10,7 +10,7 @@ module Mailboxer
   class Engine < Rails::Engine
     initializer "mailboxer.models.messageable" do
       ActiveSupport.on_load(:active_record) do
-        extend Mailboxer::Models::Messageable::ActiveRecord
+        extend Mailboxer::Models::Messageable::ActiveRecordExtension
       end
     end
   end

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -3,7 +3,7 @@ module Mailboxer
     module Messageable
       extend ActiveSupport::Concern
 
-      module ActiveRecord
+      module ActiveRecordExtension
         #Converts the model into messageable allowing it to interchange messages and
         #receive notifications
         def acts_as_messageable


### PR DESCRIPTION
I had:

``` ruby
class User < ActiveRecord::Base
  acts_as_messageable

  class Profile < ActiveRecord::Base
  end
end
```

Resulting in `uninitialized constant Mailboxer::Models::Messageable::ActiveRecord::Base` because ActiveRecord exists in the first ancestor: `Mailboxer::Models::Messageable`

I could have done `class Profile < ::ActiveRecord::Base` but well...
