### PR TITLE
Fixed unexpired and expired scopes for notifications and added scope tes...

### DIFF
--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -23,9 +23,9 @@ class Mailboxer::Notification < ActiveRecord::Base
     joins(:receipts).where('mailboxer_receipts.is_read' => false)
   }
   scope :global, lambda { where(:global => true) }
-  scope :expired, lambda { where("notifications.expires < ?", Time.now) }
+  scope :expired, lambda { where("mailboxer_notifications.expires < ?", Time.now) }
   scope :unexpired, lambda {
-    where("notifications.expires is NULL OR notifications.expires > ?", Time.now)
+    where("mailboxer_notifications.expires is NULL OR mailboxer_notifications.expires > ?", Time.now)
   }
 
   include Concerns::ConfigurableMailer

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -94,13 +94,28 @@ describe Mailboxer::Notification do
   end
 
   describe "scopes" do
-    let!(:notification) { @entity1.notify("Body", "Subject").notification }
+    let(:scope_user) { FactoryGirl.create(:user) }
+    let!(:notification) { scope_user.notify("Body", "Subject").notification }
 
     describe ".unread" do
       it "finds unread notifications" do
-        unread_notification = @entity1.notify("Body", "Subject").notification
-        notification.mark_as_read(@entity1)
+        unread_notification = scope_user.notify("Body", "Subject").notification
+        notification.mark_as_read(scope_user)
         Mailboxer::Notification.unread.last.should == unread_notification
+      end
+    end
+
+    describe ".expired" do
+      it "finds expired notifications" do
+        notification.update_attributes(expires: 1.day.ago)
+        scope_user.mailbox.notifications.expired.count.should eq(1)
+      end
+    end
+
+    describe ".unexpired" do
+      it "finds unexpired notifications" do
+        notification.update_attributes(expires: 1.day.from_now)
+        scope_user.mailbox.notifications.unexpired.count.should eq(1)
       end
     end
   end


### PR DESCRIPTION
While using this gem it was discovered that the scopes unexpired and expired on Notifications are currently broken.  Here's a fix for them (was a minor change - just needed to add the namespace to the notifications table - but I added test coverage for the scopes as well).
