### PR TITLE
Using i18n to set default_from

### DIFF
--- a/app/mailers/mailboxer/base_mailer.rb
+++ b/app/mailers/mailboxer/base_mailer.rb
@@ -1,5 +1,5 @@
 class Mailboxer::BaseMailer < ActionMailer::Base
-  default :from => Mailboxer.default_from
+  default :from => t('mailboxer.default_from', default: Mailboxer.default_from)
 
   private
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,4 @@ en:
       subject_reply: "Mailboxer new reply: %{subject}"
     notification_mailer:
       subject: "Mailboxer new notification: %{subject}"
+    default_fromt: "no-reply@mailboxer.com"


### PR DESCRIPTION
Using i18n to set default_from instead of setting the value from the mailboxer initializer.

Now, in this way could be set depending on the language in addition to the existing mode.
