### PR TITLE
configuration options for maximum length of subject and body.

### DIFF
--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -7,7 +7,8 @@ class Mailboxer::Conversation < ActiveRecord::Base
   has_many :messages, :dependent => :destroy, :class_name => "Mailboxer::Message"
   has_many :receipts, :through => :messages,  :class_name => "Mailboxer::Receipt"
 
-  validates_presence_of :subject
+  validates :subject, :presence => true,
+                      :length => { :maximum => Mailboxer.subject_max_length }
 
   before_validation :clean
 

--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -8,7 +8,10 @@ class Mailboxer::Notification < ActiveRecord::Base
   belongs_to :notified_object, :polymorphic => :true
   has_many :receipts, :dependent => :destroy, :class_name => "Mailboxer::Receipt"
 
-  validates_presence_of :subject, :body
+  validates :subject, :presence => true,
+                      :length => { :maximum => Mailboxer.subject_max_length }
+  validates :body,    :presence => true,
+                      :length => { :maximum => Mailboxer.body_max_length }
 
   scope :recipient, lambda { |recipient|
     joins(:receipts).where('mailboxer_receipts.receiver_id' => recipient.id,'mailboxer_receipts.receiver_type' => recipient.class.base_class.to_s)

--- a/lib/generators/mailboxer/templates/initializer.rb
+++ b/lib/generators/mailboxer/templates/initializer.rb
@@ -14,4 +14,8 @@ Mailboxer.setup do |config|
   #Supported engines: [:solr,:sphinx]
   config.search_enabled = false
   config.search_engine = :solr
+
+  #Configures maximum length of the message subject and body
+  config.subject_max_length = 255
+  config.body_max_length = 32000
 end

--- a/lib/mailboxer.rb
+++ b/lib/mailboxer.rb
@@ -17,6 +17,10 @@ module Mailboxer
   @@email_method = :mailboxer_email
   mattr_accessor :name_method
   @@name_method = :name
+  mattr_accessor :subject_max_length
+  @@subject_max_length = 255
+  mattr_accessor :body_max_length
+  @@body_max_length = 32000
   mattr_accessor :notification_mailer
   mattr_accessor :message_mailer
   mattr_accessor :custom_deliver_proc

--- a/mailboxer.gemspec
+++ b/mailboxer.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   # Specs
   s.add_development_dependency('rspec-rails', '>= 2.6.1')
   s.add_development_dependency("appraisal")
+  s.add_development_dependency('shoulda-matchers')
   # Fixtures
   #if RUBY_VERSION >= '1.9.2'
    # s.add_development_dependency('factory_girl', '>= 3.0.0')

--- a/spec/dummy/config/initializers/mailboxer.rb
+++ b/spec/dummy/config/initializers/mailboxer.rb
@@ -14,4 +14,8 @@ Mailboxer.setup do |config|
   #Supported enignes: [:solr,:sphinx] 
   config.search_enabled = false
   config.search_engine = :solr
+
+  #Configures maximum length of the message subject and body
+  config.subject_max_length = 255
+  config.body_max_length = 32000
 end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -12,6 +12,9 @@ describe Mailboxer::Conversation do
   let!(:message4) { receipt4.notification }
   let!(:conversation) { message1.conversation }
 
+  it { should validate_presence_of :subject }
+  it { should ensure_length_of(:subject).is_at_most(Mailboxer.subject_max_length) }
+
   it "should have proper original message" do
     conversation.original_message.should == message1
   end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -8,6 +8,12 @@ describe Mailboxer::Notification do
     @entity3 = FactoryGirl.create(:user)
   end
 
+  it { should validate_presence_of :subject }
+  it { should validate_presence_of :body }
+
+  it { should ensure_length_of(:subject).is_at_most(Mailboxer.subject_max_length) }
+  it { should ensure_length_of(:body).is_at_most(Mailboxer.body_max_length) }
+
   it "should notify one user" do
     @entity1.notify("Subject", "Body")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,9 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 require 'factory_girl'
 Dir["#{File.dirname(__FILE__)}/factories/*.rb"].each {|f| require f}
 
+# Shoulda Matchers
+require 'shoulda/matchers'
+
 RSpec.configure do |config|
   # Remove this line if you don't want RSpec's should and should_not
   # methods or matchers


### PR DESCRIPTION
This fixes #251.
Enables maximum length configuration options in the initializer. Adds Shoulda matchers as development dependency which make the specs for presence and length validations much cleaner.
