### PR TITLE
Update Messageable (and specs) to not prepend "RE: " when replying a conversation

### DIFF
--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -75,7 +75,7 @@ module Mailboxer
       #Basic reply method. USE NOT RECOMENDED.
       #Use reply_to_sender, reply_to_all and reply_to_conversation instead.
       def reply(conversation, recipients, reply_body, subject=nil, sanitize_text=true, attachment=nil)
-        subject = subject || "RE: #{conversation.subject}"
+        subject = subject || conversation.subject
         response = messages.new({:body => reply_body, :subject => subject, :attachment => attachment})
         response.conversation = conversation
         response.recipients = recipients.is_a?(Array) ? recipients : [recipients]

--- a/spec/integration/message_and_receipt_spec.rb
+++ b/spec/integration/message_and_receipt_spec.rb
@@ -62,7 +62,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -108,7 +108,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -153,7 +153,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -248,7 +248,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -294,7 +294,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -417,7 +417,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -473,7 +473,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -599,7 +599,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -655,7 +655,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -775,7 +775,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -821,7 +821,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do
@@ -866,7 +866,7 @@ describe "Messages And Mailboxer::Receipts" do
         @message2.sender.id.should == @entity2.id
         @message2.sender.class.should == @entity2.class
         assert @message2.body.eql?"Reply body"
-        assert @message2.subject.eql?"RE: Subject"
+        assert @message2.subject.eql?"Subject"
       end
 
       it "should create proper mails" do


### PR DESCRIPTION
Prepending "RE: " creates conflicts with translations and also customization, on Messageable.reply subject.

I think that I18N should take care of this, as you already use 'mailboxer.message_mailer.subject_reply' in Mailboxer::MessageMailer, developers can include the "RE: " there if they want.

I updated the specs, all green.
