### PR TITLE
Migrate Mailboxer::Notification's STI type, when upgrading from 0.11 to 0.12

### DIFF
--- a/lib/generators/mailboxer/templates/mailboxer_namespacing_compatibility.rb
+++ b/lib/generators/mailboxer/templates/mailboxer_namespacing_compatibility.rb
@@ -9,6 +9,8 @@ class MailboxerNamespacingCompatibility < ActiveRecord::Migration
       rename_index :mailboxer_notifications, :notifications_on_conversation_id, :mailboxer_notifications_on_conversation_id
       rename_index :mailboxer_receipts,      :receipts_on_notification_id,      :mailboxer_receipts_on_notification_id
     end
+
+    Mailboxer::Notification.where(type: 'Message').update_all(type: 'Mailboxer::Message')
   end
 
   def self.down
@@ -20,5 +22,7 @@ class MailboxerNamespacingCompatibility < ActiveRecord::Migration
       rename_index :notifications, :mailboxer_notifications_on_conversation_id, :notifications_on_conversation_id
       rename_index :receipts,      :mailboxer_receipts_on_notification_id,      :receipts_on_notification_id
     end
+
+    Mailboxer::Notification.where(type: 'Mailboxer::Message').update_all(type: 'Message')
   end
 end


### PR DESCRIPTION
Due to the newly added namespaces, Mailboxer::Notification's STI type should be migrated from 'Message' to 'Mailboxer::Message'.

Otherwise, when upgrading from 0.11 to 0.12 - existing messages will "disappear".
