### PR TITLE
Added missing STI and reference indices

### DIFF
--- a/db/migrate/20131206080417_add_missing_indices.rb
+++ b/db/migrate/20131206080417_add_missing_indices.rb
@@ -1,0 +1,19 @@
+class AddMissingIndices < ActiveRecord::Migration
+  def change
+    # We'll explicitly specify its name, as the auto-generated name is too long and exceeds 63
+    # characters limitation.
+    add_index :mailboxer_conversation_opt_outs, [:unsubscriber_id, :unsubscriber_type],
+      name: 'index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type'
+    add_index :mailboxer_conversation_opt_outs, :conversation_id
+
+    add_index :mailboxer_notifications, :type
+    add_index :mailboxer_notifications, [:sender_id, :sender_type]
+
+    # We'll explicitly specify its name, as the auto-generated name is too long and exceeds 63
+    # characters limitation.
+    add_index :mailboxer_notifications, [:notified_object_id, :notified_object_type],
+      name: 'index_mailboxer_notifications_on_notified_object_id_and_type'
+
+    add_index :mailboxer_receipts, [:receiver_id, :receiver_type]
+  end
+end

--- a/lib/generators/mailboxer/install_generator.rb
+++ b/lib/generators/mailboxer/install_generator.rb
@@ -18,7 +18,11 @@ class Mailboxer::InstallGenerator < Rails::Generators::Base #:nodoc:
 
   def copy_migrations
     if Rails.version < "3.1"
-      migrations = [["20110511145103_create_mailboxer.rb","create_mailboxer.rb"], ["20131206080416_add_conversation_optout.rb","add_conversation_optout.rb"]],
+      migrations = [
+        %w[20110511145103_create_mailboxer.rb create_mailboxer.rb],
+        %w[20131206080416_add_conversation_optout.rb add_conversation_optout.rb],
+        %w[20131206080417_add_missing_indices.rb add_missing_indices.rb]
+      ],
       migrations.each do |migration|
         migration_template "../../../../db/migrate/" + migration[0], "db/migrate/" + migration[1]
       end


### PR DESCRIPTION
Added missing STI and reference indices on mailboxer_conversation_opt_outs, mailboxer_notifications, and mailboxer_receipts.

Please note, that "functional" indices (e.g., read/unread messages, etc.) should be added in the future as well.
