### PR TITLE
Added ability to empty the trash

### DIFF
--- a/app/models/mailboxer/mailbox.rb
+++ b/app/models/mailboxer/mailbox.rb
@@ -68,10 +68,11 @@ class Mailboxer::Mailbox
     Mailboxer::Receipt.where(options).recipient(messageable)
   end
 
-  #Deletes all the messages in the trash of messageable. NOT IMPLEMENTED.
+  #Deletes all the messages in the trash of messageable.
   def empty_trash(options = {})
-    #TODO
-    false
+    trash(options).each do |conversation|
+      conversation.mark_as_deleted(messageable)
+    end
   end
 
   #Returns if messageable is a participant of conversation

--- a/spec/models/mailbox_spec.rb
+++ b/spec/models/mailbox_spec.rb
@@ -88,13 +88,12 @@ describe Mailboxer::Mailbox do
     @entity2.mailbox.receipts.trash.count.should==0
   end
 
-  it "should delete trashed mails (TODO)" do
+  it "should delete trashed mails" do
     @entity1.mailbox.receipts.move_to_trash
-    #TODO
-    #@entity1.mailbox.empty_trash
+    @entity1.mailbox.empty_trash
 
     assert @entity1.mailbox.receipts.trash
-    #@entity1.mailbox.receipts.trash.count.should==0
+    @entity1.mailbox.receipts.trash.count.should==0
 
     assert @entity2.mailbox.receipts
     @entity2.mailbox.receipts.count.should==4


### PR DESCRIPTION
The mailbox trash can now be emptied.

``` ruby
# get user
user = User.find(1)
# get trash
user.mailbox.trash
# empty trash
user.mailbox.empty_trash
```
