### PR TITLE
fixed a small typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ end
 You may change whatever you want or need. For example:
 
 ```ruby
-config.email_method = :notifications_email
+config.email_method = :notification_email
 config.name_method = :display_name
 ```
 


### PR DESCRIPTION
The concerned line is hidden in the diff, so here's a quick preview:

<pre>
config.email_method = <b>:notifications_email</b>
config.name_method = :display_name
</pre>
<pre>
Will use the method <b>notification_email(object)</b> instead of mailboxer_email(object) and display_name for name.
</pre>