### PR TITLE
Allow sender to be specified for a Notification

### DIFF
--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -33,13 +33,14 @@ class Mailboxer::Notification < ActiveRecord::Base
 
   class << self
     #Sends a Notification to all the recipients
-    def notify_all(recipients, subject, body, obj = nil, sanitize_text = true, notification_code=nil, send_mail=true)
+    def notify_all(recipients, subject, body, obj = nil, sanitize_text = true, notification_code=nil, send_mail=true, sender=nil)
       notification = Mailboxer::NotificationBuilder.new({
         :recipients        => recipients,
         :subject           => subject,
         :body              => body,
         :notified_object   => obj,
-        :notification_code => notification_code
+        :notification_code => notification_code,
+        :sender            => sender
       }).build
 
       notification.deliver sanitize_text, send_mail

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -56,8 +56,8 @@ module Mailboxer
       end
 
       #Sends a notification to the messageable
-      def notify(subject,body,obj = nil,sanitize_text=true,notification_code=nil,send_mail=true)
-        Mailboxer::Notification.notify_all([self],subject,body,obj,sanitize_text,notification_code,send_mail)
+      def notify(subject,body,obj = nil,sanitize_text=true,notification_code=nil,send_mail=true,sender=nil)
+        Mailboxer::Notification.notify_all([self],subject,body,obj,sanitize_text,notification_code,send_mail,sender)
       end
 
       #Sends a messages, starting a new conversation, with the messageable

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -99,6 +99,26 @@ describe Mailboxer::Notification do
     expect(notification.body).to eq "Body"
   end
 
+  it "should be able to specify a sender for a notification" do
+
+    Mailboxer::Notification.notify_all(@entity1,"Subject","Body", nil, true, nil, false, @entity3)
+
+    #Check getting ALL receipts
+    expect(@entity1.mailbox.receipts.size).to eq 1
+    receipt      = @entity1.mailbox.receipts.first
+    notification = receipt.notification
+    expect(notification.subject).to eq "Subject"
+    expect(notification.body).to eq "Body"
+    expect(notification.sender).to eq @entity3
+
+    #Check getting NOTIFICATION receipts only
+    expect(@entity1.mailbox.notifications.size).to eq 1
+    notification = @entity1.mailbox.notifications.first
+    expect(notification.subject).to eq "Subject"
+    expect(notification.body).to eq "Body"
+    expect(notification.sender).to eq @entity3
+  end
+
   describe "scopes" do
     let(:scope_user) { FactoryGirl.create(:user) }
     let!(:notification) { scope_user.notify("Body", "Subject").notification }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -46,6 +46,13 @@ describe Mailboxer::Notification do
     expect(notification).to be_is_read(@entity1)
   end
 
+  it "should be able to specify a sender for a notification" do
+    @entity1.notify("Subject", "Body", nil, true, nil, true, @entity3)
+    expect(@entity1.mailbox.receipts.size).to eq 1
+    notification = @entity1.mailbox.receipts.first.notification
+    expect(notification.sender).to eq(@entity3)
+  end
+
   it "should notify several users" do
     recipients = [@entity1,@entity2,@entity3]
     Mailboxer::Notification.notify_all(recipients,"Subject","Body")
@@ -100,7 +107,6 @@ describe Mailboxer::Notification do
   end
 
   it "should be able to specify a sender for a notification" do
-
     Mailboxer::Notification.notify_all(@entity1,"Subject","Body", nil, true, nil, false, @entity3)
 
     #Check getting ALL receipts


### PR DESCRIPTION
As mentioned in the description. At some point I might want to do some refactoring to reduce the Arity of this `notify_all` method, but wanted this feature in my own application to customize the sender of a Notification, so thought would submit contribution to upstream as well.