### PR TITLE
Relying on id in addition to the created_at timestamp to load entries chronologically

### DIFF
--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -96,7 +96,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
 
   #Last message in the conversation.
   def last_message
-    @last_message ||= messages.order('created_at DESC').first
+    @last_message ||= messages.order('created_at DESC, id DESC').first
   end
 
   #Returns the receipts of the conversation for one participants

--- a/app/models/mailboxer/mailbox.rb
+++ b/app/models/mailboxer/mailbox.rb
@@ -9,7 +9,7 @@ class Mailboxer::Mailbox
   #Returns the notifications for the messageable
   def notifications(options = {})
     #:type => nil is a hack not to give Messages as Notifications
-    notifs = Mailboxer::Notification.recipient(messageable).where(:type => nil).order("mailboxer_notifications.created_at DESC")
+    notifs = Mailboxer::Notification.recipient(messageable).where(:type => nil).order("mailboxer_notifications.created_at DESC, mailboxer_notifications.id DESC")
     if options[:read] == false || options[:unread]
       notifs = notifs.unread
     end

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -15,10 +15,10 @@ module Mailboxer
       included do
         has_many :messages, :class_name => "Mailboxer::Message", :as => :sender
         if Rails::VERSION::MAJOR == 4
-          has_many :receipts, -> { order 'created_at DESC' }, :class_name => "Mailboxer::Receipt", dependent: :destroy,     as: :receiver
+          has_many :receipts, -> { order 'created_at DESC, id DESC' }, :class_name => "Mailboxer::Receipt", dependent: :destroy,     as: :receiver
         else
           # Rails 3 does it this way
-          has_many :receipts, :order => 'created_at DESC',    :class_name => "Mailboxer::Receipt", :dependent => :destroy, :as => :receiver
+          has_many :receipts, :order => 'created_at DESC, id DESC',    :class_name => "Mailboxer::Receipt", :dependent => :destroy, :as => :receiver
         end
       end
 


### PR DESCRIPTION
It happens of messages were created nearly instantly (in test cases for example) that they get the same  `created_at`,  which results in the wrong `conversation#last_message`.  taking the ID into consideration can be helpful if the created_at are for any reason equal
