### PR TITLE
Rails version checked only for 4.x and 3.x. 

### DIFF
--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -14,7 +14,7 @@ module Mailboxer
 
       included do
         has_many :messages, :class_name => "Mailboxer::Message", :as => :sender
-        if Rails::VERSION::MAJOR == 4
+        if Rails::VERSION::MAJOR >= 4
           has_many :receipts, -> { order 'created_at DESC' }, :class_name => "Mailboxer::Receipt", dependent: :destroy,     as: :receiver
         else
           # Rails 3 does it this way


### PR DESCRIPTION
Rails 5 defaulted to 3.x behaviour. I changed the check to include anything after Rails 3.