### PR TITLE
Conversation participants

### DIFF
--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -96,7 +96,7 @@ class Mailboxer::Notification < ActiveRecord::Base
   #Returns the recipients of the Notification
   def recipients
     return Array.wrap(@recipients) unless @recipients.blank?
-    @recipients = receipts.map { |receipt| receipt.receiver }
+    @recipients = receipts.includes(:receiver).map { |receipt| receipt.receiver }
   end
 
   #Returns the receipt for the participant


### PR DESCRIPTION
With using gem [bullet](https://github.com/flyerhzm/bullet) in my project, and according to [open issue](https://github.com/mailboxer/mailboxer/issues/246) I have deal with N+1 query when I tried display participants from conversation. 

This solution remove that query and I think it can be helpful for others.