### PR TITLE
append namespace to AttachmentUploader

### DIFF
--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -11,7 +11,7 @@ class Mailboxer::Message < Mailboxer::Notification
     where(:conversation_id => conversation.id)
   }
 
-  mount_uploader :attachment, AttachmentUploader
+  mount_uploader :attachment, Mailboxer::AttachmentUploader
 
   class << self
     #Sets the on deliver callback method.


### PR DESCRIPTION
`Mailboxer::AttachmentUploader` is not in the nesting, so we need to use qualified constant name