### PR TITLE
Remove trailing spaces, convert tabs to spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ receipts.each do |receipt|
 end
 ```
 
-### How can I reply a message?
+### How can I reply to a message?
 
 ```ruby
 #alfa wants to reply to all in a conversation

--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -115,17 +115,17 @@ class Mailboxer::Conversation < ActiveRecord::Base
     receipts_for(participant).any?
   end
 
-	#Adds a new participant to the conversation
-	def add_participant(participant)
-		messages.each do |message|
+  #Adds a new participant to the conversation
+  def add_participant(participant)
+    messages.each do |message|
       Mailboxer::ReceiptBuilder.new({
         :notification => message,
         :receiver     => participant,
         :updated_at   => message.updated_at,
         :created_at   => message.created_at
       }).build.save
-		end
-	end
+    end
+  end
 
   #Returns true if the participant has at least one trashed message of the conversation
   def is_trashed?(participant)

--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -163,7 +163,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
   end
 
   # Creates a opt out object
-  # because by default all particpants are opt in
+  # because by default all participants are opt in
   def opt_out(participant)
     return unless has_subscriber?(participant)
     opt_outs.create(:unsubscriber => participant)

--- a/app/views/mailboxer/notification_mailer/new_notification_email.text.erb
+++ b/app/views/mailboxer/notification_mailer/new_notification_email.text.erb
@@ -1,6 +1,6 @@
 You have a new notification: <%= @notification.subject.html_safe? ? @notification.subject : strip_tags(@notification.subject) %>
 ===============================================
- 
+
 You have received a new notification:
 
 -----------------------------------------------

--- a/db/migrate/20110511145103_create_mailboxer.rb
+++ b/db/migrate/20110511145103_create_mailboxer.rb
@@ -1,13 +1,13 @@
 class CreateMailboxer < ActiveRecord::Migration
-  def self.up    
+  def self.up
   #Tables
-  	#Conversations
+    #Conversations
     create_table :mailboxer_conversations do |t|
       t.column :subject, :string, :default => ""
       t.column :created_at, :datetime, :null => false
       t.column :updated_at, :datetime, :null => false
-    end    
-  	#Receipts
+    end
+    #Receipts
     create_table :mailboxer_receipts do |t|
       t.references :receiver, :polymorphic => true
       t.column :notification_id, :integer, :null => false
@@ -17,8 +17,8 @@ class CreateMailboxer < ActiveRecord::Migration
       t.column :mailbox_type, :string, :limit => 25
       t.column :created_at, :datetime, :null => false
       t.column :updated_at, :datetime, :null => false
-    end    
-  	#Notifications and Messages
+    end
+    #Notifications and Messages
     create_table :mailboxer_notifications do |t|
       t.column :type, :string
       t.column :body, :text
@@ -33,30 +33,29 @@ class CreateMailboxer < ActiveRecord::Migration
       t.column :created_at, :datetime, :null => false
       t.boolean :global, default: false
       t.datetime :expires
-    end    
-    
-    
-  #Indexes
-  	#Conversations
-  	#Receipts
-  	add_index "mailboxer_receipts","notification_id"
+    end
 
-  	#Messages  
-  	add_index "mailboxer_notifications","conversation_id"
-  
-  #Foreign keys    
-  	#Conversations
-  	#Receipts
-  	add_foreign_key "mailboxer_receipts", "mailboxer_notifications", :name => "receipts_on_notification_id", :column => "notification_id"
-  	#Messages  
-  	add_foreign_key "mailboxer_notifications", "mailboxer_conversations", :name => "notifications_on_conversation_id", :column => "conversation_id"
+  #Indexes
+    #Conversations
+    #Receipts
+    add_index "mailboxer_receipts","notification_id"
+
+    #Messages
+    add_index "mailboxer_notifications","conversation_id"
+
+  #Foreign keys
+    #Conversations
+    #Receipts
+    add_foreign_key "mailboxer_receipts", "mailboxer_notifications", :name => "receipts_on_notification_id", :column => "notification_id"
+    #Messages
+    add_foreign_key "mailboxer_notifications", "mailboxer_conversations", :name => "notifications_on_conversation_id", :column => "conversation_id"
   end
-  
+
   def self.down
-  #Tables  	
-  	remove_foreign_key "mailboxer_receipts", :name => "receipts_on_notification_id"
-  	remove_foreign_key "mailboxer_notifications", :name => "notifications_on_conversation_id"
-  	
+  #Tables
+    remove_foreign_key "mailboxer_receipts", :name => "receipts_on_notification_id"
+    remove_foreign_key "mailboxer_notifications", :name => "notifications_on_conversation_id"
+
   #Indexes
     drop_table :mailboxer_receipts
     drop_table :mailboxer_conversations


### PR DESCRIPTION
Most of the project uses spaces, with the exception of a few
lines in a couple of files.  This commit simply cleans that up.

A few instances of trailing spaces were removed.