### PR TITLE
Sets the mailbox_type to 'inbox' in Conversation#add_participant

### DIFF
--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -122,7 +122,8 @@ class Mailboxer::Conversation < ActiveRecord::Base
         :notification => message,
         :receiver     => participant,
         :updated_at   => message.updated_at,
-        :created_at   => message.created_at
+        :created_at   => message.created_at,
+        :mailbox_type => 'inbox'
       }).build.save
     end
   end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -67,6 +67,7 @@ describe Mailboxer::Conversation do
     expect(conversation.participants.count).to eq 3
     expect(conversation.participants).to include(new_user, entity1, entity2)
     expect(conversation.receipts_for(new_user).count).to eq conversation.receipts_for(entity1).count
+    expect(conversation.receipts_for(new_user).map(&:mailbox_type).uniq).to eq ['inbox']
   end
 
   it "should deliver messages to new participants" do


### PR DESCRIPTION
Fixes https://github.com/mailboxer/mailboxer/issues/393