### PR TITLE
Change ActiveRecord::QueryMethods#uniq to ActiveRecord::QueryMethods#distinct

### DIFF
--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -15,7 +15,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
   scope :participant, lambda {|participant|
     where('mailboxer_notifications.type'=> Mailboxer::Message.name).
     order("mailboxer_conversations.updated_at DESC").
-    joins(:receipts).merge(Mailboxer::Receipt.recipient(participant)).uniq
+    joins(:receipts).merge(Mailboxer::Receipt.recipient(participant)).distinct
   }
   scope :inbox, lambda {|participant|
     participant(participant).merge(Mailboxer::Receipt.inbox.not_trash.not_deleted)
@@ -36,7 +36,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
     joins("INNER JOIN (#{Mailboxer::Notification.recipient(participant_two).to_sql}) `participant_two_notifications` ON `participant_two_notifications`.`conversation_id` = `mailboxer_conversations`.`id` AND `participant_two_notifications`.`type` IN ('Mailboxer::Message')").
         joins("INNER JOIN `mailboxer_receipts` ON `mailboxer_receipts`.`notification_id` = `participant_two_notifications`.`id` ").
         merge(Mailboxer::Receipt.recipient(participant_one)).
-        order("mailboxer_conversations.updated_at DESC").uniq
+        order("mailboxer_conversations.updated_at DESC").distinct
   }
 
   #Mark the conversation as read for one of the participants


### PR DESCRIPTION
This solve deprecation warning for Rails 5, it doesn't change any behavior because uniq method is an alias to distinct