### PR TITLE
Feature pg search

### DIFF
--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -45,4 +45,11 @@ class Mailboxer::Message < Mailboxer::Notification
     end
     sender_receipt
   end
+
+  if Mailboxer.search_enabled
+    if Mailboxer.search_engine == :pg_search
+      include PgSearch
+      pg_search_scope :search, against: [:subject, :body]
+    end
+  end
 end

--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -151,14 +151,21 @@ class Mailboxer::Receipt < ActiveRecord::Base
   end
 
   if Mailboxer.search_enabled
-    searchable do
-      text :subject, :boost => 5 do
-        message.subject if message
+    if Mailboxer.search_engine == :pg_search
+      include PgSearch
+      pg_search_scope :search, associated_against: {
+        message: [:subject, :body]
+      }
+    else
+      searchable do
+        text :subject, :boost => 5 do
+          message.subject if message
+        end
+        text :body do
+          message.body if message
+        end
+        integer :receiver_id
       end
-      text :body do
-        message.body if message
-      end
-      integer :receiver_id
     end
   end
 end

--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -151,21 +151,14 @@ class Mailboxer::Receipt < ActiveRecord::Base
   end
 
   if Mailboxer.search_enabled
-    if Mailboxer.search_engine == :pg_search
-      include PgSearch
-      pg_search_scope :search, associated_against: {
-        message: [:subject, :body]
-      }
-    else
-      searchable do
-        text :subject, :boost => 5 do
-          message.subject if message
-        end
-        text :body do
-          message.body if message
-        end
-        integer :receiver_id
+    searchable do
+      text :subject, :boost => 5 do
+        message.subject if message
       end
+      text :body do
+        message.body if message
+      end
+      integer :receiver_id
     end
   end
 end

--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -151,14 +151,16 @@ class Mailboxer::Receipt < ActiveRecord::Base
   end
 
   if Mailboxer.search_enabled
-    searchable do
-      text :subject, :boost => 5 do
-        message.subject if message
+    if Mailboxer.search_engine != :pg_search
+      searchable do
+        text :subject, :boost => 5 do
+          message.subject if message
+        end
+        text :body do
+          message.body if message
+        end
+        integer :receiver_id
       end
-      text :body do
-        message.body if message
-      end
-      integer :receiver_id
     end
   end
 end

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -230,12 +230,17 @@ module Mailboxer
       end
 
       def search_messages(query)
-        @search = Mailboxer::Receipt.search do
-          fulltext query
-          with :receiver_id, self.id
-        end
+        if Mailboxer.search_engine == :pg_search
+          @search = Mailboxer::Receipt.search(query)
+          @search.map { |r| r.conversation }.uniq
+        else
+          @search = Mailboxer::Receipt.search do
+            fulltext query
+            with :receiver_id, self.id
+          end
 
-        @search.results.map { |r| r.conversation }.uniq
+          @search.results.map { |r| r.conversation }.uniq
+        end
       end
     end
   end


### PR DESCRIPTION
Why:
- I didn't have access to `:solr` or `:sphinx` and wanted to still do a search.
- Using `PostgreSQL` the best searching gem I've used was [pg_search](https://github.com/Casecommons/pg_search)

This change addresses the need by:
- Add a check for `:pg_search` option since it works differently than the other searches.
- Add `searchable` to a `message`.
- Remove `searchable` for receipts if `pg_search` is enabled.
