### PR TITLE
Allow messages without a subject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ sudo: false
 rvm:
   - 2
 
-matrix:
-  include:
-    - rvm: 2.0
-      gemfile: gemfiles/rails4.1.gemfile
-
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2
+  - 2.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
 
 gemfile:
   - gemfiles/rails3.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ rvm:
 
 matrix:
   include:
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails4.1.gemfile
     - rvm: 2.0
-      gemfile: gemfiles/rails4.1.gemfile
-    - rvm: jruby-19mode
       gemfile: gemfiles/rails4.1.gemfile
 
 gemfile:

--- a/app/builders/mailboxer/message_builder.rb
+++ b/app/builders/mailboxer/message_builder.rb
@@ -5,12 +5,4 @@ class Mailboxer::MessageBuilder < Mailboxer::BaseBuilder
   def klass
     Mailboxer::Message
   end
-
-  def subject
-    params[:subject] || default_subject
-  end
-
-  def default_subject
-    "#{params[:conversation].subject}"
-  end
 end

--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -34,8 +34,8 @@ class Mailboxer::Message < Mailboxer::Notification
     temp_receipts = [sender_receipt] + receiver_receipts
 
     if temp_receipts.all?(&:valid?)
-      Mailboxer::MailDispatcher.new(self, receiver_receipts).call
       temp_receipts.each(&:save!)
+      Mailboxer::MailDispatcher.new(self, receiver_receipts).call
 
       conversation.touch if reply
 

--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -8,8 +8,7 @@ class Mailboxer::Notification < ActiveRecord::Base
   belongs_to :notified_object, :polymorphic => :true
   has_many :receipts, :dependent => :destroy, :class_name => "Mailboxer::Receipt"
 
-  validates :subject, :presence => true,
-                      :length => { :maximum => Mailboxer.subject_max_length }
+  validates :subject, :length => { :maximum => Mailboxer.subject_max_length }
   validates :body,    :presence => true,
                       :length => { :maximum => Mailboxer.body_max_length }
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -8,7 +8,6 @@ describe Mailboxer::Notification do
     @entity3 = FactoryGirl.create(:user)
   end
 
-  it { should validate_presence_of :subject }
   it { should validate_presence_of :body }
 
   it { should validate_length_of(:subject).is_at_most(Mailboxer.subject_max_length) }


### PR DESCRIPTION
Also fixes another problem that could happen during url generation in email templates.