### PR TITLE
Remove defunct Rails version checks

### DIFF
--- a/lib/generators/mailboxer/install_generator.rb
+++ b/lib/generators/mailboxer/install_generator.rb
@@ -17,20 +17,9 @@ class Mailboxer::InstallGenerator < Rails::Generators::Base #:nodoc:
   end
 
   def copy_migrations
-    if Rails.version < "3.1"
-      migrations = [
-        %w[20110511145103_create_mailboxer.rb create_mailboxer.rb],
-        %w[20131206080416_add_conversation_optout.rb add_conversation_optout.rb],
-        %w[20131206080417_add_missing_indices.rb add_missing_indices.rb]
-      ],
-      migrations.each do |migration|
-        migration_template "../../../../db/migrate/" + migration[0], "db/migrate/" + migration[1]
-      end
-    else
-      require 'rake'
-      Rails.application.load_tasks
-      Rake::Task['railties:install:migrations'].reenable
-      Rake::Task['mailboxer_engine:install:migrations'].invoke
-    end
+    require 'rake'
+    Rails.application.load_tasks
+    Rake::Task['railties:install:migrations'].reenable
+    Rake::Task['mailboxer_engine:install:migrations'].invoke
   end
 end

--- a/lib/generators/mailboxer/templates/mailboxer_namespacing_compatibility.rb
+++ b/lib/generators/mailboxer/templates/mailboxer_namespacing_compatibility.rb
@@ -5,11 +5,6 @@ class MailboxerNamespacingCompatibility < ActiveRecord::Migration
     rename_table :notifications, :mailboxer_notifications
     rename_table :receipts,      :mailboxer_receipts
 
-    if Rails.version < '4'
-      rename_index :mailboxer_notifications, :notifications_on_conversation_id, :mailboxer_notifications_on_conversation_id
-      rename_index :mailboxer_receipts,      :receipts_on_notification_id,      :mailboxer_receipts_on_notification_id
-    end
-
     Mailboxer::Notification.where(type: 'Message').update_all(type: 'Mailboxer::Message')
   end
 
@@ -17,11 +12,6 @@ class MailboxerNamespacingCompatibility < ActiveRecord::Migration
     rename_table :mailboxer_conversations, :conversations
     rename_table :mailboxer_notifications, :notifications
     rename_table :mailboxer_receipts,      :receipts
-
-    if Rails.version < '4'
-      rename_index :notifications, :mailboxer_notifications_on_conversation_id, :notifications_on_conversation_id
-      rename_index :receipts,      :mailboxer_receipts_on_notification_id,      :receipts_on_notification_id
-    end
 
     Mailboxer::Notification.where(type: 'Mailboxer::Message').update_all(type: 'Message')
   end

--- a/lib/mailboxer.rb
+++ b/lib/mailboxer.rb
@@ -29,7 +29,7 @@ module Mailboxer
     end
 
     def protected_attributes?
-      Rails.version < '4' || defined?(ProtectedAttributes)
+      defined?(ProtectedAttributes)
     end
   end
 


### PR DESCRIPTION
Since the gemspec has Rails 4.2 and later as a dependency, the old < 4
version checks for Rails should never be executed. This removes the now
dead code.