### PR TITLE
Add a change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# CHANGELOG
+
+## Master (Unreleased)
+
+## 0.14.0 - 2016-07-29
+
+### Added
+
+* Rails 5 compatibility.
+
+### Fixed
+
+* `Mailboxer::Message` object no longer requires to have a subject.
+* Objects are now saved before mails are sent, you you can use them in the
+mailer templates (to build URLs, for example).
+
+### Changed
+
+* Errors are now stored in the parent message/notification instead of being
+stored in the sender receipt. That means you need handle mailboxer related
+controller and views differently, and study the upgrade case by case (propably
+by having a look at mailboxer's source code). As an example, if you were
+previously doing something like this in your controller:
+
+```
+@receipt = @actor.send_message(@recipients, params[:body], params[:subject])
+if (@receipt.errors.blank?)
+  @conversation = @receipt.conversation
+  redirect_to conversation_path(@conversation)
+else
+  render :action => :new
+end
+```
+
+you now need to do something like
+
+```
+@receipt = @actor.send_message(@recipients, params[:body], params[:subject])
+@message = @receipt.message
+if (@message.errors.blank?)
+  @conversation = @message.conversation
+  redirect_to conversation_path(@conversation)
+else
+  render :action => :new
+end
+```
+
+This might look more complicated at first but allows you to build more RESTful
+resources since you can build forms on messages and/or conversations and
+directly show errors on them. Less specially handling is now required to
+propagate errors around models.


### PR DESCRIPTION
I've seen #430 and realized that latests changes are backwards incompatible regarding errors when sending messages. I think this is fine at this point (`0.x` series), but we need to document the changes.

There's A LOT of changes missing in there since the previous releases, I've just dropped there some changes I've made.