### PR TITLE
fix conversations require a subject

### DIFF
--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -7,8 +7,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
   has_many :messages, :dependent => :destroy, :class_name => "Mailboxer::Message"
   has_many :receipts, :through => :messages,  :class_name => "Mailboxer::Receipt"
 
-  validates :subject, :presence => true,
-                      :length => { :maximum => Mailboxer.subject_max_length }
+  validates :subject, :length => { :maximum => Mailboxer.subject_max_length }
 
   before_validation :clean
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -12,7 +12,6 @@ describe Mailboxer::Conversation do
   let!(:message4) { receipt4.notification }
   let!(:conversation) { message1.conversation }
 
-  it { should validate_presence_of :subject }
   it { should validate_length_of(:subject).is_at_most(Mailboxer.subject_max_length) }
 
   it "should have proper original message" do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -7,21 +7,6 @@ describe Mailboxer::Message do
     @entity2 = FactoryGirl.create(:user)
   end
 
-  context "with errors" do
-    describe "empty subject" do
-      before do
-        @receipt1 = @entity1.send_message(@entity2,"Body","")
-        @message1 = @receipt1.notification
-      end
-
-      it "should add errors to the created notification" do
-        errors = @message1.errors['conversation.subject']
-
-        expect(errors).to eq(["can't be blank"])
-      end
-    end
-  end
-
   context "after send" do
 
     before do


### PR DESCRIPTION
Hi, for a more chat-like environment, we would like to start conversations and send messages without subjects.
In the last release (0.14.0) the subject validation was removed from the Mailboxer::Message object (#115), but not from Mailboxer::Conversation (which by the way made the validation test fail).
I removed the subject validation from Mailboxer::Conversation and the corresponding test.
