### PR TITLE
Added ability to specify custom mailers per mailable subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ Mailboxer.setup do |config|
 end
 ```
 
+If you have subclassed the Mailboxer::Notification class, you can specify the mailers using a member method:
+
+```
+class NewDocumentNotification < Mailboxer::Notification
+  def mailer_class
+    NewDocumentNotificationMailer
+  end
+end
+
+class NewCommentNotification < Mailboxer::Notification
+  def mailer_class
+    NewDocumentNotificationMailer
+  end
+end
+```
+
+Otherwise, the mailer class will be determined by appending 'Mailer' to the mailable class name.
+
 ### User identities
 
 Users must have an identity defined by a `name` and an `email`. We must ensure that Messageable models have some specific methods. These methods are:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ end
 
 If you have subclassed the Mailboxer::Notification class, you can specify the mailers using a member method:
 
-```
+```ruby
 class NewDocumentNotification < Mailboxer::Notification
   def mailer_class
     NewDocumentNotificationMailer

--- a/lib/mailboxer/mail_dispatcher.rb
+++ b/lib/mailboxer/mail_dispatcher.rb
@@ -18,9 +18,21 @@ module Mailboxer
     private
 
     def mailer
+      mailer_config_method || mailer_from_mailable || mailer_constant
+    end
+
+    def mailer_from_mailable
+      mailable.mailer_class if mailable.respond_to? :mailer_class
+    end
+
+    def mailer_config_method
       klass = mailable.class.name.demodulize
       method = "#{klass.downcase}_mailer".to_sym
-      Mailboxer.send(method) || "#{mailable.class}Mailer".constantize
+      Mailboxer.send(method) if Mailboxer.respond_to? method
+    end
+
+    def mailer_constant
+      "#{mailable.class.name}Mailer".constantize
     end
 
     def send_email(receipt)

--- a/spec/mailboxer/mail_dispatcher_spec.rb
+++ b/spec/mailboxer/mail_dispatcher_spec.rb
@@ -63,7 +63,7 @@ describe Mailboxer::MailDispatcher do
   describe "mailer" do
     let(:receipts) { [] }
 
-    context "mailable is a Message" do
+    context "mailable is a Notification" do
       let(:mailable) { Mailboxer::Notification.new }
 
       its(:mailer) { should be Mailboxer::NotificationMailer }
@@ -76,15 +76,26 @@ describe Mailboxer::MailDispatcher do
       end
     end
 
-    context "mailable is a Notification" do
+    context "mailable is a Message" do
       let(:mailable) { Mailboxer::Message.new }
       its(:mailer) { should be Mailboxer::MessageMailer }
 
-      context "with custom mailer" do
+      context 'mailer class is selected using global Mailboxer method' do
         before { Mailboxer.message_mailer = 'foo' }
         after  { Mailboxer.message_mailer = nil   }
 
         its(:mailer) { should eq 'foo' }
+      end
+
+      context 'mailer class is selected using Mailable#mailer_class' do
+        let(:mailable) { double(mailer_class: :foo) }
+        its(:mailer) { should eq :foo }
+      end
+
+      context 'mailer class is selected by searching for the constant' do
+        before { stub_const 'StringMailer', 1 }
+        let(:mailable) { String.new('I am a string') }
+        its(:mailer) { should eq Object.const_get('StringMailer') }
       end
     end
   end


### PR DESCRIPTION
In our project we are subclassing Mailboxer::Notification to create different types of notifications.  We have different ways of rendering these on the front-end as well as for emails.

I've altered the MailDispatcher so that it's possible to override the mailer per mailable.  The old behaviour remains the same; the addition should be transparent.
