### PR TITLE
Use both created_at and id to order entires in proper order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master (Unreleased)
 
+### Changed
+
+* When sorting entries by `created_at`, also sort by `id` descending. This
+is to ensure proper sorting of items for databases that do not store
+nanoseconds for timestamp columns.
+
 ## 0.14.0 - 2016-07-29
 
 ### Added

--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -103,7 +103,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
 
   #Last message in the conversation.
   def last_message
-    @last_message ||= messages.order('created_at DESC').first
+    @last_message ||= messages.order(:created_at => :desc, :id => :desc).first
   end
 
   #Returns the receipts of the conversation for one participants

--- a/app/models/mailboxer/mailbox.rb
+++ b/app/models/mailboxer/mailbox.rb
@@ -9,7 +9,7 @@ class Mailboxer::Mailbox
   #Returns the notifications for the messageable
   def notifications(options = {})
     #:type => nil is a hack not to give Messages as Notifications
-    notifs = Mailboxer::Notification.recipient(messageable).where(:type => nil).order("mailboxer_notifications.created_at DESC")
+    notifs = Mailboxer::Notification.recipient(messageable).where(:type => nil).order(:created_at => :desc, :id => :desc)
     if options[:read] == false || options[:unread]
       notifs = notifs.unread
     end

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -14,7 +14,7 @@ module Mailboxer
 
       included do
         has_many :messages, :class_name => "Mailboxer::Message", :as => :sender
-        has_many :receipts, -> { order 'created_at DESC' }, :class_name => "Mailboxer::Receipt", dependent: :destroy, as: :receiver
+        has_many :receipts, -> { order(:created_at => :desc, :id => :desc) }, :class_name => "Mailboxer::Receipt", dependent: :destroy, as: :receiver
       end
 
       unless defined?(Mailboxer.name_method)


### PR DESCRIPTION
This is a reimplementation of PR #361 with a rebase and an updated changelog.

When using databases that do not store nanoseconds in timestamp columns, a possible race condition can happen where two messages in a conversation could be submitted at the same time. By adding an additional order by scope, this ensure the objects queried are ordered in the exact order they were created.