### PR TITLE
Use hashes and symbols for wheres where applicable

### DIFF
--- a/app/models/mailboxer/conversation.rb
+++ b/app/models/mailboxer/conversation.rb
@@ -93,7 +93,7 @@ class Mailboxer::Conversation < ActiveRecord::Base
 
   #First message of the conversation.
   def original_message
-    @original_message ||= messages.order('created_at').first
+    @original_message ||= messages.order(:created_at).first
   end
 
   #Sender of the last message.

--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -13,21 +13,21 @@ class Mailboxer::Notification < ActiveRecord::Base
                       :length => { :maximum => Mailboxer.body_max_length }
 
   scope :recipient, lambda { |recipient|
-    joins(:receipts).where('mailboxer_receipts.receiver_id' => recipient.id,'mailboxer_receipts.receiver_type' => recipient.class.base_class.to_s)
+    joins(:receipts).where(:mailboxer_receipts => { :receiver_id  => recipient.id, :receiver_type => recipient.class.base_class.to_s })
   }
   scope :with_object, lambda { |obj|
-    where('notified_object_id' => obj.id,'notified_object_type' => obj.class.to_s)
+    where(:notified_object_id => obj.id, :notified_object_type => obj.class.to_s)
   }
   scope :not_trashed, lambda {
-    joins(:receipts).where('mailboxer_receipts.trashed' => false)
+    joins(:receipts).where(:mailboxer_receipts => { :trashed => false })
   }
   scope :unread,  lambda {
-    joins(:receipts).where('mailboxer_receipts.is_read' => false)
+    joins(:receipts).where(:mailboxer_receipts => { :is_read => false })
   }
   scope :global, lambda { where(:global => true) }
-  scope :expired, lambda { where("mailboxer_notifications.expires < ?", Time.now) }
+  scope :expired, lambda { where("#{Mailboxer::Notification.quoted_table_name}.expires < ?", Time.now) }
   scope :unexpired, lambda {
-    where("mailboxer_notifications.expires is NULL OR mailboxer_notifications.expires > ?", Time.now)
+    where("#{Mailboxer::Notification.quoted_table_name}.expires is NULL OR #{Mailboxer::Notification.quoted_table_name}.expires > ?", Time.now)
   }
 
   class << self


### PR DESCRIPTION
This swaps out of some of the manual strings to use the table's name in join queries along with strings for column names with the "Rails way" of using hashes and symbols.