### PR TITLE
Add missing namespaces so Mailboxer objects may be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 is to ensure proper sorting of items for databases that do not store
 nanoseconds for timestamp columns.
 
+### Fixed
+
+* When trying to delete a Mailboxer object, a `NameError` may be thrown due
+to a missing namespace
+
 ## 0.14.0 - 2016-07-29
 
 ### Added

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -169,11 +169,11 @@ module Mailboxer
       #* An array with any of them
       def mark_as_deleted(obj)
         case obj
-          when Receipt
+          when Mailboxer::Receipt
             return obj.mark_as_deleted if obj.receiver == self
-          when Message, Notification
+          when Mailboxer::Message, Mailboxer::Notification
             obj.mark_as_deleted(self)
-          when Conversation
+          when Mailboxer::Conversation
             obj.mark_as_deleted(self)
           when Array
             obj.map{ |sub_obj| mark_as_deleted(sub_obj) }


### PR DESCRIPTION
Reimplements PR #413 which should fix Issue #385 - Adds a missing namespace for the code used to delete a `Mailboxer` object. Ruby is most likely getting confused as to where in the constant tree to grab the proper class for the case statement.

Ran into this same issue on my app a bit ago.