### PR TITLE
Allow the name of the `notify` method to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Mailboxer.setup do |config|
   #Configures the methods needed by mailboxer
   config.email_method = :mailboxer_email
   config.name_method = :name
+  config.notify_method = :notify
   # ...
 end
 ```
@@ -144,9 +145,10 @@ You may change whatever you want or need. For example:
 ```ruby
 config.email_method = :notification_email
 config.name_method = :display_name
+config.notify_method = :notify_mailboxer
 ```
 
-Will use the method `notification_email(object)` instead of `mailboxer_email(object)` and `display_name` for `name`.
+Will use the method `notification_email(object)` instead of `mailboxer_email(object)`, `display_name` for `name` and `notify_mailboxer` for `notify`.
 
 Using default or custom method names, if your model doesn't implement them, Mailboxer will use dummy methods so as to notify you of missing methods rather than crashing.
 

--- a/lib/generators/mailboxer/templates/initializer.rb
+++ b/lib/generators/mailboxer/templates/initializer.rb
@@ -9,6 +9,7 @@ Mailboxer.setup do |config|
   #Configures the methods needed by mailboxer
   config.email_method = :mailboxer_email
   config.name_method = :name
+  config.notify_method = :notify
 
   #Configures if you use or not a search engine and which one you are using
   #Supported engines: [:solr,:sphinx]

--- a/lib/mailboxer.rb
+++ b/lib/mailboxer.rb
@@ -15,6 +15,8 @@ module Mailboxer
   @@email_method = :mailboxer_email
   mattr_accessor :name_method
   @@name_method = :name
+  mattr_accessor :notify_method
+  @@email_method = :notify
   mattr_accessor :subject_max_length
   @@subject_max_length = 255
   mattr_accessor :body_max_length

--- a/lib/mailboxer.rb
+++ b/lib/mailboxer.rb
@@ -16,7 +16,7 @@ module Mailboxer
   mattr_accessor :name_method
   @@name_method = :name
   mattr_accessor :notify_method
-  @@email_method = :notify
+  @@notify_method = :notify
   mattr_accessor :subject_max_length
   @@subject_max_length = 255
   mattr_accessor :body_max_length

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -40,6 +40,11 @@ module Mailboxer
         end
       end
 
+      #Sends a notification to the messageable
+      define_method Mailboxer.notify_method do |subject, body, obj=nil, sanitize_text=true, notification_code=nil, send_mail=true, sender=nil|
+        Mailboxer::Notification.notify_all([self],subject,body,obj,sanitize_text,notification_code,send_mail,sender)
+      end
+
       #Gets the mailbox of the messageable
       def mailbox
         @mailbox ||= Mailboxer::Mailbox.new(self)
@@ -48,11 +53,6 @@ module Mailboxer
       # Get number of unread messages
       def unread_inbox_count
         mailbox.inbox(unread: true).count
-      end
-
-      #Sends a notification to the messageable
-      def notify(subject,body,obj = nil,sanitize_text=true,notification_code=nil,send_mail=true,sender=nil)
-        Mailboxer::Notification.notify_all([self],subject,body,obj,sanitize_text,notification_code,send_mail,sender)
       end
 
       #Sends a messages, starting a new conversation, with the messageable

--- a/spec/dummy/config/initializers/mailboxer.rb
+++ b/spec/dummy/config/initializers/mailboxer.rb
@@ -1,17 +1,18 @@
 Mailboxer.setup do |config|
-  
+
   #Configures if you applications uses or no the email sending for Notifications and Messages
   config.uses_emails = true
-  
+
   #Configures the default from for the email sent for Messages and Notifications of Mailboxer
   config.default_from = "no-reply@mailboxer.com"
-  
+
   #Configures the methods needed by mailboxer
   config.email_method = :mailboxer_email
   config.name_method = :name
+  config.notify_method = :notify
 
   #Configures if you use or not a search engine and wich one are you using
-  #Supported enignes: [:solr,:sphinx] 
+  #Supported enignes: [:solr,:sphinx]
   config.search_enabled = false
   config.search_engine = :solr
 

--- a/spec/models/mailboxer_models_messageable_spec.rb
+++ b/spec/models/mailboxer_models_messageable_spec.rb
@@ -170,7 +170,7 @@ describe "Mailboxer::Models::Messageable through User" do
 
 
   it "should be able to unread an owned Notification (mark as unread)" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.is_read).to eq false
     @entity1.mark_as_read(@notification)
@@ -179,7 +179,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should be able to read an owned Notification (mark as read)" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.is_read).to eq false
     @entity1.mark_as_read(@notification)
@@ -187,7 +187,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should not be able to unread a not owned Notification (mark as unread)" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.is_read).to eq false
     @entity1.mark_as_read(@notification)
@@ -196,7 +196,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should not be able to read a not owned Notification (mark as read)" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.is_read).to eq false
     @entity2.mark_as_read(@notification)
@@ -204,7 +204,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should be able to trash an owned Notification" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.trashed).to eq false
     @entity1.trash(@notification)
@@ -212,7 +212,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should be able to untrash an owned Notification" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.trashed).to eq false
     @entity1.trash(@notification)
@@ -221,7 +221,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should not be able to trash a not owned Notification" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.trashed).to eq false
     @entity2.trash(@notification)
@@ -229,7 +229,7 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should not be able to untrash a not owned Notification" do
-    @receipt = @entity1.notify("Subject","Body")
+    @receipt = @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     @notification = @receipt.notification
     expect(@receipt.trashed).to eq false
     @entity1.trash(@notification)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -14,7 +14,7 @@ describe Mailboxer::Notification do
   it { should validate_length_of(:body).is_at_most(Mailboxer.body_max_length) }
 
   it "should notify one user" do
-    @entity1.notify("Subject", "Body")
+    @entity1.send(Mailboxer.notify_method, "Subject", "Body")
 
     #Check getting ALL receipts
     expect(@entity1.mailbox.receipts.size).to eq 1
@@ -31,14 +31,14 @@ describe Mailboxer::Notification do
   end
 
   it "should be unread by default" do
-    @entity1.notify("Subject", "Body")
+    @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     expect(@entity1.mailbox.receipts.size).to eq 1
     notification = @entity1.mailbox.receipts.first.notification
     expect(notification).to be_is_unread(@entity1)
   end
 
   it "should be able to marked as read" do
-    @entity1.notify("Subject", "Body")
+    @entity1.send(Mailboxer.notify_method, "Subject", "Body")
     expect(@entity1.mailbox.receipts.size).to eq 1
     notification = @entity1.mailbox.receipts.first.notification
     notification.mark_as_read(@entity1)
@@ -46,7 +46,7 @@ describe Mailboxer::Notification do
   end
 
   it "should be able to specify a sender for a notification" do
-    @entity1.notify("Subject", "Body", nil, true, nil, true, @entity3)
+    @entity1.send(Mailboxer.notify_method, "Subject", "Body", nil, true, nil, true, @entity3)
     expect(@entity1.mailbox.receipts.size).to eq 1
     notification = @entity1.mailbox.receipts.first.notification
     expect(notification.sender).to eq(@entity3)
@@ -126,11 +126,11 @@ describe Mailboxer::Notification do
 
   describe "scopes" do
     let(:scope_user) { FactoryGirl.create(:user) }
-    let!(:notification) { scope_user.notify("Body", "Subject").notification }
+    let!(:notification) { scope_user.send(Mailboxer.notify_method, "Body", "Subject").notification }
 
     describe ".unread" do
       it "finds unread notifications" do
-        unread_notification = scope_user.notify("Body", "Subject").notification
+        unread_notification = scope_user.send(Mailboxer.notify_method, "Body", "Subject").notification
         notification.mark_as_read(scope_user)
         expect(Mailboxer::Notification.unread.last).to eq unread_notification
       end


### PR DESCRIPTION
`notify` is a common method name used by other gems and in existing
codebases - this change allows the notification method name to be
overridden as part of the configuration for Mailboxer, to avoid method
name clash with existing models that might already be using `.notify`