### PR TITLE
Drop Carrierwave in favor of an attachments model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ class Cylon < ActiveRecord::Base
 end
 ```
 
+## Attachments
+
+We are "uploader" agnostic but we require that the attachment is attached to a
+polymorphic object that exposes two methods, a name and a file.
+
+
 ## Mailboxer API
 
 ### Warning for version 0.8.0

--- a/app/mailers/mailboxer/base_mailer.rb
+++ b/app/mailers/mailboxer/base_mailer.rb
@@ -11,4 +11,11 @@ class Mailboxer::BaseMailer < ActionMailer::Base
     ::Mailboxer::Cleaner.instance.strip_tags(text)
   end
 
+  def attach_message_attachments
+    return unless @message.respond_to?(:attachments)
+    @message.attachments.each do |attachment|
+      attachments[attachment.send(Mailboxer.attachment_filename_method)] =
+        attachment.send(Mailboxer.attachment_file_method)
+    end
+  end
 end

--- a/app/mailers/mailboxer/message_mailer.rb
+++ b/app/mailers/mailboxer/message_mailer.rb
@@ -15,6 +15,8 @@ class Mailboxer::MessageMailer < Mailboxer::BaseMailer
     @message  = message
     @receiver = receiver
     set_subject(message)
+    attach_message_attachments
+
     mail :to => receiver.send(Mailboxer.email_method, message),
          :subject => t('mailboxer.message_mailer.subject_new', :subject => @subject),
          :template_name => 'new_message_email'
@@ -25,6 +27,8 @@ class Mailboxer::MessageMailer < Mailboxer::BaseMailer
     @message  = message
     @receiver = receiver
     set_subject(message)
+    attach_message_attachments
+
     mail :to => receiver.send(Mailboxer.email_method, message),
          :subject => t('mailboxer.message_mailer.subject_reply', :subject => @subject),
          :template_name => 'reply_message_email'

--- a/app/mailers/mailboxer/notification_mailer.rb
+++ b/app/mailers/mailboxer/notification_mailer.rb
@@ -10,6 +10,7 @@ class Mailboxer::NotificationMailer < Mailboxer::BaseMailer
     @notification = notification
     @receiver     = receiver
     set_subject(notification)
+    attach_message_attachments
     mail :to => receiver.send(Mailboxer.email_method, notification),
          :subject => t('mailboxer.notification_mailer.subject', :subject => @subject),
          :template_name => 'new_notification_email'

--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -1,8 +1,12 @@
 class Mailboxer::Message < Mailboxer::Notification
-  attr_accessible :attachment if Mailboxer.protected_attributes?
   self.table_name = :mailboxer_notifications
 
   belongs_to :conversation, :validate => true, :autosave => true
+
+  if Mailboxer.attachments_model
+    has_many :attachments, as: Mailboxer.attachments_model.table_name.singularize.downcase + 'able', class_name: Mailboxer.attachments_model.to_s
+  end
+
   validates_presence_of :sender
 
   class_attribute :on_deliver_callback
@@ -10,8 +14,6 @@ class Mailboxer::Message < Mailboxer::Notification
   scope :conversation, lambda { |conversation|
     where(:conversation_id => conversation.id)
   }
-
-  mount_uploader :attachment, Mailboxer::AttachmentUploader
 
   class << self
     #Sets the on deliver callback method.

--- a/app/uploaders/mailboxer/attachment_uploader.rb
+++ b/app/uploaders/mailboxer/attachment_uploader.rb
@@ -1,3 +1,0 @@
-class Mailboxer::AttachmentUploader < CarrierWave::Uploader::Base
-  storage :file
-end

--- a/db/migrate/20110511145103_create_mailboxer.rb
+++ b/db/migrate/20110511145103_create_mailboxer.rb
@@ -28,7 +28,6 @@ class CreateMailboxer < ActiveRecord::Migration[4.2]
       t.column :draft, :boolean, :default => false
       t.string :notification_code, :default => nil
       t.references :notified_object, :polymorphic => true, index: { name: 'mailboxer_notifications_notified_object' }
-      t.column :attachment, :string
       t.column :updated_at, :datetime, :null => false
       t.column :created_at, :datetime, :null => false
       t.boolean :global, default: false

--- a/lib/mailboxer.rb
+++ b/lib/mailboxer.rb
@@ -24,6 +24,11 @@ module Mailboxer
   mattr_accessor :notification_mailer
   mattr_accessor :message_mailer
   mattr_accessor :custom_deliver_proc
+  mattr_accessor :attachments_model
+  mattr_accessor :attachment_file_method
+  @@attachment_file_method = :file
+  mattr_accessor :attachment_filename_method
+  @@attachment_file_method = :filename
 
   class << self
     def setup

--- a/lib/mailboxer/engine.rb
+++ b/lib/mailboxer/engine.rb
@@ -1,4 +1,3 @@
-require 'carrierwave'
 begin
   require 'sunspot_rails'
 rescue LoadError

--- a/lib/mailboxer/models/messageable.rb
+++ b/lib/mailboxer/models/messageable.rb
@@ -57,7 +57,7 @@ module Mailboxer
 
       #Sends a messages, starting a new conversation, with the messageable
       #as originator
-      def send_message(recipients, msg_body, subject, sanitize_text=true, attachment=nil, message_timestamp = Time.now)
+      def send_message(recipients, msg_body, subject, sanitize_text=true, attachments=nil, message_timestamp = Time.now)
         convo = Mailboxer::ConversationBuilder.new({
           :subject    => subject,
           :created_at => message_timestamp,
@@ -70,7 +70,7 @@ module Mailboxer
           :recipients   => recipients,
           :body         => msg_body,
           :subject      => subject,
-          :attachment   => attachment,
+          :attachments  => attachments,
           :created_at   => message_timestamp,
           :updated_at   => message_timestamp
         }).build
@@ -80,7 +80,7 @@ module Mailboxer
 
       #Basic reply method. USE NOT RECOMENDED.
       #Use reply_to_sender, reply_to_all and reply_to_conversation instead.
-      def reply(conversation, recipients, reply_body, subject=nil, sanitize_text=true, attachment=nil)
+      def reply(conversation, recipients, reply_body, subject=nil, sanitize_text=true, attachments=nil)
         subject = subject || "#{conversation.subject}"
         response = Mailboxer::MessageBuilder.new({
           :sender       => self,
@@ -88,7 +88,7 @@ module Mailboxer
           :recipients   => recipients,
           :body         => reply_body,
           :subject      => subject,
-          :attachment   => attachment
+          :attachments   => attachments
         }).build
 
         response.recipients.delete(self)
@@ -96,25 +96,25 @@ module Mailboxer
       end
 
       #Replies to the sender of the message in the conversation
-      def reply_to_sender(receipt, reply_body, subject=nil, sanitize_text=true, attachment=nil)
-        reply(receipt.conversation, receipt.message.sender, reply_body, subject, sanitize_text, attachment)
+      def reply_to_sender(receipt, reply_body, subject=nil, sanitize_text=true, attachments=nil)
+        reply(receipt.conversation, receipt.message.sender, reply_body, subject, sanitize_text, attachments)
       end
 
       #Replies to all the recipients of the message in the conversation
-      def reply_to_all(receipt, reply_body, subject=nil, sanitize_text=true, attachment=nil)
-        reply(receipt.conversation, receipt.message.recipients, reply_body, subject, sanitize_text, attachment)
+      def reply_to_all(receipt, reply_body, subject=nil, sanitize_text=true, attachments=nil)
+        reply(receipt.conversation, receipt.message.recipients, reply_body, subject, sanitize_text, attachments)
       end
 
       #Replies to all the recipients of the last message in the conversation and untrash any trashed message by messageable
       #if should_untrash is set to true (this is so by default)
-      def reply_to_conversation(conversation, reply_body, subject=nil, should_untrash=true, sanitize_text=true, attachment=nil)
+      def reply_to_conversation(conversation, reply_body, subject=nil, should_untrash=true, sanitize_text=true, attachments=nil)
         #move conversation to inbox if it is currently in the trash and should_untrash parameter is true.
         if should_untrash && mailbox.is_trashed?(conversation)
           mailbox.receipts_for(conversation).untrash
           mailbox.receipts_for(conversation).mark_as_not_deleted
         end
 
-        reply(conversation, conversation.last_message.recipients, reply_body, subject, sanitize_text, attachment)
+        reply(conversation, conversation.last_message.recipients, reply_body, subject, sanitize_text, attachments)
       end
 
       #Mark the object as read for messageable.

--- a/mailboxer.gemspec
+++ b/mailboxer.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
 
   # Development Gem dependencies
   s.add_runtime_dependency('rails', '>= 5.0.0')
-  s.add_runtime_dependency('carrierwave', '>= 0.5.8')
 
   if RUBY_ENGINE == "rbx" && RUBY_VERSION >= "2.1.0"
     # Rubinius has it's own dependencies

--- a/spec/dummy/app/models/fake_attachment.rb
+++ b/spec/dummy/app/models/fake_attachment.rb
@@ -1,0 +1,12 @@
+# It's fake
+class FakeAttachment < ActiveRecord::Base
+  belongs_to :fake_attachmentable, polymorphic: true
+
+  def file
+    File.read('spec/testfile.txt')
+  end
+
+  def filename
+    'testfile.txt'
+  end
+end

--- a/spec/dummy/config/initializers/mailboxer.rb
+++ b/spec/dummy/config/initializers/mailboxer.rb
@@ -19,4 +19,9 @@ Mailboxer.setup do |config|
   #Configures maximum length of the message subject and body
   config.subject_max_length = 255
   config.body_max_length = 32000
+
+  # Configure Attachments
+  config.attachments_model = FakeAttachment
+  config.attachment_file_method = :file
+  config.attachment_filename_method = :filename
 end

--- a/spec/dummy/db/migrate/20160306015107_create_fake_attachments.rb
+++ b/spec/dummy/db/migrate/20160306015107_create_fake_attachments.rb
@@ -1,0 +1,16 @@
+class CreateFakeAttachments < ActiveRecord::Migration[4.2]
+  def self.up
+    create_table :fake_attachments do |t|
+      t.integer :fake_attachmentable_id
+      t.string :fake_attachmentable_type
+      t.string :file
+      t.string :filename
+
+      t.timestamps null: false
+    end
+  end
+
+  def self.down
+    drop_table :fake_attachments
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -50,7 +50,6 @@ ActiveRecord::Schema.define(:version => 20131206080416) do
     t.string   "notification_code"
     t.integer  "conversation_id"
     t.boolean  "draft",                :default => false
-    t.string   "attachment"
     t.datetime "updated_at",                              :null => false
     t.datetime "created_at",                              :null => false
     t.boolean  "global",               :default => false
@@ -62,6 +61,7 @@ ActiveRecord::Schema.define(:version => 20131206080416) do
   create_table "mailboxer_receipts", :force => true do |t|
     t.integer  "receiver_id"
     t.string   "receiver_type"
+    t.string   "message_id"
     t.integer  "notification_id",                                  :null => false
     t.boolean  "is_read",                       :default => false
     t.boolean  "trashed",                       :default => false

--- a/spec/models/mailboxer_models_messageable_spec.rb
+++ b/spec/models/mailboxer_models_messageable_spec.rb
@@ -308,9 +308,9 @@ describe "Mailboxer::Models::Messageable through User" do
   end
 
   it "should be able to read attachment" do
-    @receipt = @entity1.send_message(@entity2, "Body", "Subject", nil, File.open('spec/testfile.txt'))
+    @receipt = @entity1.send_message(@entity2, "Body", "Subject", nil, [FakeAttachment.create])
     @conversation = @receipt.conversation
-    expect(@conversation.messages.first.attachment_identifier).to eq 'testfile.txt'
+    expect(@receipt.message.attachments.first.filename).to eq 'testfile.txt'
   end
 
   it "should be the same message time as passed" do


### PR DESCRIPTION
This is a step towards becoming uploader agnostic, as carrierwave is one of many gems that support file upload having that dependency inside of mailboxer makes it reasonably heavy.

This also intrinsically supports multiple attachments. 

This is very much so a breaking api change.  Ideally we add various migrations paths, but at least we need to add one for those who have been using carrierwave.