### PR TITLE
Add not trashed conversations example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ alfa.mailbox.sentbox
 
 #alfa wants to retrieve his trashed conversations
 alfa.mailbox.trash
+
+#Also wants to retrieve not trashed conversations
+alfa.mailbox.conversations({ :mailbox_type => 'not_trash' })
+
 ```
 
 ### How can I paginate conversations?


### PR DESCRIPTION
I had to read the source code to do it.
I found this line makes it work so easy:
https://github.com/mailboxer/mailboxer/blob/master/app/models/mailboxer/mailbox.rb#L126
