### PR TITLE
chore(rails): account for update_attributes -> update deprecation

### DIFF
--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -80,42 +80,42 @@ class Mailboxer::Receipt < ActiveRecord::Base
 
   #Marks the receipt as deleted
   def mark_as_deleted
-    update_attributes(:deleted => true)
+    update(:deleted => true)
   end
 
   #Marks the receipt as not deleted
   def mark_as_not_deleted
-    update_attributes(:deleted => false)
+    update(:deleted => false)
   end
 
   #Marks the receipt as read
   def mark_as_read
-    update_attributes(:is_read => true)
+    update(:is_read => true)
   end
 
   #Marks the receipt as unread
   def mark_as_unread
-    update_attributes(:is_read => false)
+    update(:is_read => false)
   end
 
   #Marks the receipt as trashed
   def move_to_trash
-    update_attributes(:trashed => true)
+    update(:trashed => true)
   end
 
   #Marks the receipt as not trashed
   def untrash
-    update_attributes(:trashed => false)
+    update(:trashed => false)
   end
 
   #Moves the receipt to inbox
   def move_to_inbox
-    update_attributes(:mailbox_type => :inbox, :trashed => false)
+    update(:mailbox_type => :inbox, :trashed => false)
   end
 
   #Moves the receipt to sentbox
   def move_to_sentbox
-    update_attributes(:mailbox_type => :sentbox, :trashed => false)
+    update(:mailbox_type => :sentbox, :trashed => false)
   end
 
   #Returns the conversation associated to the receipt if the notification is a Message

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -138,14 +138,14 @@ describe Mailboxer::Notification do
 
     describe ".expired" do
       it "finds expired notifications" do
-        notification.update_attributes(expires: 1.day.ago)
+        notification.update(expires: 1.day.ago)
         expect(scope_user.mailbox.notifications.expired.count).to eq(1)
       end
     end
 
     describe ".unexpired" do
       it "finds unexpired notifications" do
-        notification.update_attributes(expires: 1.day.from_now)
+        notification.update(expires: 1.day.from_now)
         expect(scope_user.mailbox.notifications.unexpired.count).to eq(1)
       end
     end


### PR DESCRIPTION
Mailboxer produces the following warnings in Rails 6.0.0:

`DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead)`

see also: https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/