### PR TITLE
Run tests against more recent Ruby and Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,20 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.2.5
-  - 2.3.1
-  - 2.4.1
-
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 gemfile:
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
+  - gemfiles/rails5.2.gemfile
+  - gemfiles/rails5.6.gemfile
+
+matrix:
+  exclude:
+    - rvm: 2.4.9
+      gemfile: gemfiles/rails6.0.gemfile
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ gemfile:
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
-  - gemfiles/rails5.6.gemfile
+  - gemfiles/rails6.0.gemfile
 
 matrix:
   exclude:

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 5.2.0"
+
+gemspec :path => "../"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 6.0.0"
+
+gemspec :path => "../"

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,11 +19,15 @@ Capybara.default_driver   = :rack_test
 Capybara.default_selector = :css
 
 # Run any available migration
-if Rails.gem_version >= Gem::Version.new('5.2.0')
-  ActiveRecord::MigrationContext.new(File.expand_path('../dummy/db/migrate', __FILE__)).migrate
+migrate_path = File.expand_path('../dummy/db/migrate', __FILE__)
+if Rails.version.start_with? '6'
+  ActiveRecord::MigrationContext.new(migrate_path, ActiveRecord::SchemaMigration).migrate
+elsif Rails.version.start_with? '5.2'
+  ActiveRecord::MigrationContext.new(migrate_path).migrate
 else
-  ActiveRecord::Migrator.migrate File.expand_path("../dummy/db/migrate/", __FILE__)
+  ActiveRecord::Migrator.migrate migrate_path
 end
+
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 


### PR DESCRIPTION
- dropping test runs for Ruby 2.2.x and 2.3.x
- adding test runs under Ruby 2.5 and 2.6 
- testing against Rails 5.2 and Rails 6