### PR TITLE
Add optional to belongs_to in all models

### DIFF
--- a/app/models/mailboxer/conversation/opt_out.rb
+++ b/app/models/mailboxer/conversation/opt_out.rb
@@ -3,8 +3,8 @@ module Mailboxer
     class OptOut < ActiveRecord::Base
       self.table_name = :mailboxer_conversation_opt_outs
 
-      belongs_to :conversation, :class_name  => "Mailboxer::Conversation"
-      belongs_to :unsubscriber, :polymorphic => true
+      belongs_to :conversation, :class_name  => "Mailboxer::Conversation", optional: true
+      belongs_to :unsubscriber, :polymorphic => true, optional: true
 
       validates :unsubscriber, :presence => true
 

--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -2,7 +2,7 @@ class Mailboxer::Message < Mailboxer::Notification
   attr_accessible :attachment if Mailboxer.protected_attributes?
   self.table_name = :mailboxer_notifications
 
-  belongs_to :conversation, :validate => true, :autosave => true
+  belongs_to :conversation, :validate => true, :autosave => true, optional: true
   validates_presence_of :sender
 
   class_attribute :on_deliver_callback

--- a/app/models/mailboxer/notification.rb
+++ b/app/models/mailboxer/notification.rb
@@ -4,8 +4,8 @@ class Mailboxer::Notification < ActiveRecord::Base
   attr_accessor :recipients
   attr_accessible :body, :subject, :global, :expires if Mailboxer.protected_attributes?
 
-  belongs_to :sender, :polymorphic => :true, :required => false
-  belongs_to :notified_object, :polymorphic => :true, :required => false
+  belongs_to :sender, :polymorphic => :true, :required => false, optional: true
+  belongs_to :notified_object, :polymorphic => :true, :required => false, optional: true
   has_many :receipts, :dependent => :destroy, :class_name => "Mailboxer::Receipt"
 
   validates :subject, :length => { :maximum => Mailboxer.subject_max_length }

--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -1,134 +1,137 @@
+# frozen_string_literal: true
+
 class Mailboxer::Receipt < ActiveRecord::Base
   self.table_name = :mailboxer_receipts
-  attr_accessible :trashed, :is_read, :deleted if Mailboxer.protected_attributes?
+  if Mailboxer.protected_attributes?
+    attr_accessible :trashed, :is_read, :deleted
+  end
 
-  belongs_to :notification, :class_name => "Mailboxer::Notification"
-  belongs_to :receiver, :polymorphic => :true, :required => false
-  belongs_to :message, :class_name => "Mailboxer::Message", :foreign_key => "notification_id", :required => false
+  belongs_to :notification, class_name: 'Mailboxer::Notification', optional: true
+  belongs_to :receiver, polymorphic: :true, required: false, optional: true
+  belongs_to :message, class_name: 'Mailboxer::Message', foreign_key: 'notification_id', required: false, optional: true
 
   validates_presence_of :receiver
 
   scope :recipient, lambda { |recipient|
-    where(:receiver_id => recipient.id,:receiver_type => recipient.class.base_class.to_s)
+    where(receiver_id: recipient.id, receiver_type: recipient.class.base_class.to_s)
   }
-  #Notifications Scope checks type to be nil, not Notification because of STI behaviour
-  #with the primary class (no type is saved)
-  scope :notifications_receipts, lambda { joins(:notification).where(:mailboxer_notifications => { :type => nil }) }
-  scope :messages_receipts, lambda { joins(:notification).where(:mailboxer_notifications => { :type => Mailboxer::Message.to_s }) }
+  # Notifications Scope checks type to be nil, not Notification because of STI behaviour
+  # with the primary class (no type is saved)
+  scope :notifications_receipts, -> { joins(:notification).where(mailboxer_notifications: { type: nil }) }
+  scope :messages_receipts, -> { joins(:notification).where(mailboxer_notifications: { type: Mailboxer::Message.to_s }) }
   scope :notification, lambda { |notification|
-    where(:notification_id => notification.id)
+    where(notification_id: notification.id)
   }
   scope :conversation, lambda { |conversation|
-    joins(:message).where(:mailboxer_notifications => { :conversation_id => conversation.id })
+    joins(:message).where(mailboxer_notifications: { conversation_id: conversation.id })
   }
-  scope :sentbox, lambda { where(:mailbox_type => "sentbox") }
-  scope :inbox, lambda { where(:mailbox_type => "inbox") }
-  scope :trash, lambda { where(:trashed => true, :deleted => false) }
-  scope :not_trash, lambda { where(:trashed => false) }
-  scope :deleted, lambda { where(:deleted => true) }
-  scope :not_deleted, lambda { where(:deleted => false) }
-  scope :is_read, lambda { where(:is_read => true) }
-  scope :is_unread, lambda { where(:is_read => false) }
+  scope :sentbox, -> { where(mailbox_type: 'sentbox') }
+  scope :inbox, -> { where(mailbox_type: 'inbox') }
+  scope :trash, -> { where(trashed: true, deleted: false) }
+  scope :not_trash, -> { where(trashed: false) }
+  scope :deleted, -> { where(deleted: true) }
+  scope :not_deleted, -> { where(deleted: false) }
+  scope :is_read, -> { where(is_read: true) }
+  scope :is_unread, -> { where(is_read: false) }
 
   class << self
-    #Marks all the receipts from the relation as read
-    def mark_as_read(options={})
-      update_receipts({:is_read => true}, options)
+    # Marks all the receipts from the relation as read
+    def mark_as_read(options = {})
+      update_receipts({ is_read: true }, options)
     end
 
-    #Marks all the receipts from the relation as unread
-    def mark_as_unread(options={})
-      update_receipts({:is_read => false}, options)
+    # Marks all the receipts from the relation as unread
+    def mark_as_unread(options = {})
+      update_receipts({ is_read: false }, options)
     end
 
-    #Marks all the receipts from the relation as trashed
-    def move_to_trash(options={})
-      update_receipts({:trashed => true}, options)
+    # Marks all the receipts from the relation as trashed
+    def move_to_trash(options = {})
+      update_receipts({ trashed: true }, options)
     end
 
-    #Marks all the receipts from the relation as not trashed
-    def untrash(options={})
-      update_receipts({:trashed => false}, options)
+    # Marks all the receipts from the relation as not trashed
+    def untrash(options = {})
+      update_receipts({ trashed: false }, options)
     end
 
-    #Marks the receipt as deleted
-    def mark_as_deleted(options={})
-      update_receipts({:deleted => true}, options)
+    # Marks the receipt as deleted
+    def mark_as_deleted(options = {})
+      update_receipts({ deleted: true }, options)
     end
 
-    #Marks the receipt as not deleted
-    def mark_as_not_deleted(options={})
-      update_receipts({:deleted => false}, options)
+    # Marks the receipt as not deleted
+    def mark_as_not_deleted(options = {})
+      update_receipts({ deleted: false }, options)
     end
 
-    #Moves all the receipts from the relation to inbox
-    def move_to_inbox(options={})
-      update_receipts({:mailbox_type => :inbox, :trashed => false}, options)
+    # Moves all the receipts from the relation to inbox
+    def move_to_inbox(options = {})
+      update_receipts({ mailbox_type: :inbox, trashed: false }, options)
     end
 
-    #Moves all the receipts from the relation to sentbox
-    def move_to_sentbox(options={})
-      update_receipts({:mailbox_type => :sentbox, :trashed => false}, options)
+    # Moves all the receipts from the relation to sentbox
+    def move_to_sentbox(options = {})
+      update_receipts({ mailbox_type: :sentbox, trashed: false }, options)
     end
 
-    def update_receipts(updates, options={})
+    def update_receipts(updates, options = {})
       ids = where(options).pluck(:id)
-      Mailboxer::Receipt.where(:id => ids).update_all(updates) unless ids.empty?
+      Mailboxer::Receipt.where(id: ids).update_all(updates) unless ids.empty?
     end
   end
 
-
-  #Marks the receipt as deleted
+  # Marks the receipt as deleted
   def mark_as_deleted
-    update_attributes(:deleted => true)
+    update_attributes(deleted: true)
   end
 
-  #Marks the receipt as not deleted
+  # Marks the receipt as not deleted
   def mark_as_not_deleted
-    update_attributes(:deleted => false)
+    update_attributes(deleted: false)
   end
 
-  #Marks the receipt as read
+  # Marks the receipt as read
   def mark_as_read
-    update_attributes(:is_read => true)
+    update_attributes(is_read: true)
   end
 
-  #Marks the receipt as unread
+  # Marks the receipt as unread
   def mark_as_unread
-    update_attributes(:is_read => false)
+    update_attributes(is_read: false)
   end
 
-  #Marks the receipt as trashed
+  # Marks the receipt as trashed
   def move_to_trash
-    update_attributes(:trashed => true)
+    update_attributes(trashed: true)
   end
 
-  #Marks the receipt as not trashed
+  # Marks the receipt as not trashed
   def untrash
-    update_attributes(:trashed => false)
+    update_attributes(trashed: false)
   end
 
-  #Moves the receipt to inbox
+  # Moves the receipt to inbox
   def move_to_inbox
-    update_attributes(:mailbox_type => :inbox, :trashed => false)
+    update_attributes(mailbox_type: :inbox, trashed: false)
   end
 
-  #Moves the receipt to sentbox
+  # Moves the receipt to sentbox
   def move_to_sentbox
-    update_attributes(:mailbox_type => :sentbox, :trashed => false)
+    update_attributes(mailbox_type: :sentbox, trashed: false)
   end
 
-  #Returns the conversation associated to the receipt if the notification is a Message
+  # Returns the conversation associated to the receipt if the notification is a Message
   def conversation
     message.conversation if message.is_a? Mailboxer::Message
   end
 
-  #Returns if the participant have read the Notification
+  # Returns if the participant have read the Notification
   def is_unread?
     !is_read
   end
 
-  #Returns if the participant have trashed the Notification
+  # Returns if the participant have trashed the Notification
   def is_trashed?
     trashed
   end
@@ -141,11 +144,11 @@ class Mailboxer::Receipt < ActiveRecord::Base
       pg_search_scope :search, associated_against: { message: { subject: 'A', body: 'B' } }, using: :tsearch
     else
       searchable do
-        text :subject, :boost => 5 do
-          message.subject if message
+        text :subject, boost: 5 do
+          message&.subject
         end
         text :body do
-          message.body if message
+          message&.body
         end
         integer :receiver_id
       end


### PR DESCRIPTION
This PR fixes a problem introduced in Rails 6 where all belongs_to associations are required. Created on behalf of @kevinjbayer so that I can keep track of it. Closes #509 