### PR TITLE
feat(attachments): support passing in a string URL

### DIFF
--- a/app/builders/mailboxer/base_builder.rb
+++ b/app/builders/mailboxer/base_builder.rb
@@ -9,7 +9,16 @@ class Mailboxer::BaseBuilder
   def build
     klass.new.tap do |object|
       params.keys.each do |field|
-        object.send("#{field}=", get(field)) unless get(field).nil?
+        field_value = get(field)
+        next if field_value.nil?
+
+        attr = if field.to_s == "attachment" && field_value.is_a?(String)
+                 "remote_#{field}_url"
+               else
+                 field
+               end
+
+        object.send("#{attr}=", field_value)
       end
     end
   end
@@ -23,4 +32,5 @@ class Mailboxer::BaseBuilder
   def recipients
     Array(params[:recipients]).uniq
   end
+
 end


### PR DESCRIPTION
Carrierwave supports passing a file from a remote location. See [uploading files from a remote location](https://github.com/carrierwaveuploader/carrierwave#uploading-files-from-a-remote-location).