### PR TITLE
Fix postgres warning by including PgSearch::Model

### DIFF
--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -137,7 +137,7 @@ class Mailboxer::Receipt < ActiveRecord::Base
 
   if Mailboxer.search_enabled
     if Mailboxer.search_engine == :pg_search
-      include PgSearch
+      include PgSearch::Model
       pg_search_scope :search, associated_against: { message: { subject: 'A', body: 'B' } }, using: :tsearch
     else
       searchable do


### PR DESCRIPTION
PgSearch now expects you to use `include PgSearch::Model` instead of using `include PgSearch`. I was getting the error message below, which is solved by this very simple PR.

```
DEPRECATION WARNING: Directly including `PgSearch` into an Active Record model is deprecated and will be removed in pg_search 3.0.

Please replace `include PgSearch` with `include PgSearch::Model`.
```